### PR TITLE
Reset pick form on matchup navigation

### DIFF
--- a/next-app/app/matchup/page.tsx
+++ b/next-app/app/matchup/page.tsx
@@ -27,6 +27,7 @@ export default async function MatchupIndexPage({ searchParams }: MatchupIndexPag
         initialData={{ matchup: {} as any, scoreboard: null, picks: [] }}
         initialDateCode={dateCode}
         initialGameCode={''}
+        userId={user.record.id}
       />
     );
   }
@@ -42,8 +43,7 @@ export default async function MatchupIndexPage({ searchParams }: MatchupIndexPag
       initialGameCode={gameCode}
       userPick={initialData.picks.find((p) => p.user === user.record.id)}
       scoreboardStatus={initialData.scoreboard?.status || 0}
+      userId={user.record.id}
     />
   );
 }
-
-

--- a/next-app/components/matchup/matchup-page-client.tsx
+++ b/next-app/components/matchup/matchup-page-client.tsx
@@ -27,6 +27,7 @@ interface MatchupPageClientProps {
   initialData: MatchupPageData;
   initialDateCode: string;
   initialGameCode: string;
+  userId: string;
   userPick?: PickType;
   scoreboardStatus?: number;
 }
@@ -36,6 +37,7 @@ export function MatchupPageClient({
   initialData,
   initialDateCode,
   initialGameCode,
+  userId,
   userPick,
   scoreboardStatus = 0,
 }: MatchupPageClientProps) {
@@ -174,14 +176,26 @@ export function MatchupPageClient({
   // Find the current user's pick from the picks list
   // This ensures we always have the latest pick data after refetches
   const userPickForCurrent = useMemo(() => {
-    // First try to find from currentPicks (most up-to-date)
-    if (userPick?.user) {
-      const foundPick = currentPicks.find((p) => p.user === userPick.user);
-      if (foundPick) return foundPick;
+    const foundPick = currentPicks.find((p) => p.user === userId);
+    if (foundPick) return foundPick;
+
+    if (
+      userPick &&
+      userPick.user === userId &&
+      displayedCode === `${initialDateCode}/${initialGameCode}`
+    ) {
+      return userPick;
     }
-    // Fallback to userPick prop if not found in currentPicks
-    return userPick;
-  }, [currentPicks, userPick]);
+
+    return undefined;
+  }, [
+    currentPicks,
+    userId,
+    userPick,
+    displayedCode,
+    initialDateCode,
+    initialGameCode,
+  ]);
 
   // Refetch matchup data - mutations will handle optimistic updates
   const refetchMatchupData = useCallback(


### PR DESCRIPTION
Reset the pick form state when navigating between matchups to prevent displaying stale pick data.

---
<a href="https://cursor.com/background-agent?bcId=bc-3682fbfd-95b7-490a-ab0d-70b6ae4d05bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3682fbfd-95b7-490a-ab0d-70b6ae4d05bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

