### PR TITLE
Reset comment box on matchup navigation

### DIFF
--- a/next-app/components/matchup/pick-form.tsx
+++ b/next-app/components/matchup/pick-form.tsx
@@ -101,30 +101,33 @@ export function PickForm({
 
   // Handle successful submission via mutation callback
   useEffect(() => {
-    if (submitPickMutation.isSuccess && submitPickMutation.data?.pick) {
-      const submittedPick = submitPickMutation.data.pick;
+    if (!submitPickMutation.isSuccess) return;
+    const submittedPick = submitPickMutation.data?.pick;
+    if (!submittedPick) return;
 
-      setFormState({
-        win_prediction: submittedPick.win_prediction,
-        comment: submittedPick.comment || '',
-        pickId: submittedPick.id,
-        matchup: matchup.id,
-      });
+    // Ignore submissions from other matchups when navigating between games
+    if (submittedPick.matchup !== matchup.id) return;
 
-      // Close accordion with animation
-      setAccordionValue('');
+    setFormState({
+      win_prediction: submittedPick.win_prediction,
+      comment: submittedPick.comment || '',
+      pickId: submittedPick.id,
+      matchup: matchup.id,
+    });
 
-      // Callback for parent component (mutations handle React Query updates)
-      if (onPickUpdate) {
-        const currentPick = pick;
-        const optimisticPick = currentPick?.expand?.user
-          ? {
-              ...submittedPick,
-              expand: { ...currentPick.expand, user: currentPick.expand.user },
-            }
-          : submittedPick;
-        onPickUpdate(optimisticPick);
-      }
+    // Close accordion with animation
+    setAccordionValue('');
+
+    // Callback for parent component (mutations handle React Query updates)
+    if (onPickUpdate) {
+      const currentPick = pick;
+      const optimisticPick = currentPick?.expand?.user
+        ? {
+            ...submittedPick,
+            expand: { ...currentPick.expand, user: currentPick.expand.user },
+          }
+        : submittedPick;
+      onPickUpdate(optimisticPick);
     }
   }, [submitPickMutation.isSuccess, submitPickMutation.data, matchup.id, onPickUpdate, pick]);
 


### PR DESCRIPTION
Fix comment text box not resetting in pick form when navigating between matchups by adding a check to ensure the form is only rehydrated with data relevant to the current matchup.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf204ca8-0c04-4da0-b141-4b1ca404835e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bf204ca8-0c04-4da0-b141-4b1ca404835e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

