### PR TITLE
Fix past date scoreboards showing as upcoming

### DIFF
--- a/next-app/__tests__/lib/date-utils.test.ts
+++ b/next-app/__tests__/lib/date-utils.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  getCodePrefixFromDate,
+  getCurrentWeekCodePrefixes,
+  getInitialDateRange,
+  expandDateRange,
+  dateCodeToDate,
+  isToday,
+} from '@/lib/date-utils';
+
+describe('getCodePrefixFromDate', () => {
+  it('formats a date as yyyyMMdd in America/New_York timezone', () => {
+    const date = new Date('2025-01-15T12:00:00Z');
+    const result = getCodePrefixFromDate(date);
+    expect(result).toMatch(/^\d{8}$/);
+  });
+
+  it('uses Eastern Time for date calculation', () => {
+    const utcMidnight = new Date('2025-03-15T04:00:00Z');
+    const result = getCodePrefixFromDate(utcMidnight);
+    expect(result).toBe('20250315');
+  });
+
+  it('handles dates near midnight ET correctly', () => {
+    const justBeforeMidnightET = new Date('2025-03-15T03:59:00Z');
+    const result = getCodePrefixFromDate(justBeforeMidnightET);
+    expect(result).toBe('20250314');
+  });
+
+  it('pads single-digit months and days', () => {
+    const date = new Date('2025-02-05T15:00:00Z');
+    const result = getCodePrefixFromDate(date);
+    expect(result).toBe('20250205');
+  });
+});
+
+describe('getCurrentWeekCodePrefixes', () => {
+  it('returns 7 date codes', () => {
+    const result = getCurrentWeekCodePrefixes();
+    expect(result).toHaveLength(7);
+  });
+
+  it('returns codes in ascending order', () => {
+    const result = getCurrentWeekCodePrefixes();
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i] > result[i - 1]).toBe(true);
+    }
+  });
+
+  it('each code is 8 digits', () => {
+    const result = getCurrentWeekCodePrefixes();
+    for (const code of result) {
+      expect(code).toMatch(/^\d{8}$/);
+    }
+  });
+
+  it('includes today', () => {
+    const result = getCurrentWeekCodePrefixes();
+    const todayCode = getCodePrefixFromDate(new Date());
+    expect(result).toContain(todayCode);
+  });
+});
+
+describe('getInitialDateRange', () => {
+  it('returns 22 date codes (7 past + today + 14 future)', () => {
+    const result = getInitialDateRange();
+    expect(result).toHaveLength(22);
+  });
+
+  it('includes today in the range', () => {
+    const result = getInitialDateRange();
+    const todayCode = getCodePrefixFromDate(new Date());
+    expect(result).toContain(todayCode);
+  });
+
+  it('today is at index 7 (after 7 past days)', () => {
+    const result = getInitialDateRange();
+    const todayCode = getCodePrefixFromDate(new Date());
+    expect(result[7]).toBe(todayCode);
+  });
+
+  it('all codes are unique', () => {
+    const result = getInitialDateRange();
+    expect(new Set(result).size).toBe(result.length);
+  });
+});
+
+describe('expandDateRange', () => {
+  const baseRange = ['20250310', '20250311', '20250312', '20250313', '20250314'];
+
+  it('prepends dates when expanding left', () => {
+    const result = expandDateRange(baseRange, 'left', 3);
+    expect(result).toHaveLength(baseRange.length + 3);
+    expect(result.slice(3)).toEqual(baseRange.slice());
+  });
+
+  it('appends dates when expanding right', () => {
+    const result = expandDateRange(baseRange, 'right', 3);
+    expect(result).toHaveLength(baseRange.length + 3);
+    expect(result.slice(0, baseRange.length)).toEqual(baseRange);
+  });
+
+  it('prepends correct dates going backwards from earliest', () => {
+    const result = expandDateRange(baseRange, 'left', 2);
+    expect(result[0]).toBe('20250308');
+    expect(result[1]).toBe('20250309');
+  });
+
+  it('appends correct dates going forwards from latest', () => {
+    const result = expandDateRange(baseRange, 'right', 2);
+    const lastIdx = result.length - 1;
+    expect(result[lastIdx - 1]).toBe('20250315');
+    expect(result[lastIdx]).toBe('20250316');
+  });
+
+  it('returns initial date range when current range is empty', () => {
+    const result = expandDateRange([], 'left');
+    expect(result).toHaveLength(22);
+  });
+
+  it('defaults to 7 days when daysToAdd not specified', () => {
+    const result = expandDateRange(baseRange, 'right');
+    expect(result).toHaveLength(baseRange.length + 7);
+  });
+});
+
+describe('dateCodeToDate', () => {
+  it('converts a date code back to a Date object in ET', () => {
+    const result = dateCodeToDate('20250315');
+    expect(result).toBeInstanceOf(Date);
+    const etYear = result.toLocaleString('en-US', { timeZone: 'America/New_York', year: 'numeric' });
+    const etMonth = result.toLocaleString('en-US', { timeZone: 'America/New_York', month: '2-digit' });
+    const etDay = result.toLocaleString('en-US', { timeZone: 'America/New_York', day: '2-digit' });
+    expect(etYear).toBe('2025');
+    expect(etMonth).toBe('03');
+    expect(etDay).toBe('15');
+  });
+});
+
+describe('isToday', () => {
+  it('returns true for today\'s code', () => {
+    const todayCode = getCodePrefixFromDate(new Date());
+    expect(isToday(todayCode)).toBe(true);
+  });
+
+  it('returns false for a different date', () => {
+    expect(isToday('19990101')).toBe(false);
+  });
+});

--- a/next-app/__tests__/lib/definitions.test.ts
+++ b/next-app/__tests__/lib/definitions.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from 'vitest';
+import {
+  BaseZ,
+  UserZ,
+  UserSettingsZ,
+  StatZ,
+  WeeklyStatZ,
+  MatchupZ,
+  ScoreboardZ,
+  PickZ,
+  ReactionZ,
+  GameZ,
+} from '@/lib/definitions';
+
+const validBase = {
+  id: '123456789012345',
+  created: '2025-01-01T00:00:00Z',
+  updated: '2025-01-01T00:00:00Z',
+};
+
+describe('BaseZ', () => {
+  it('accepts valid base fields', () => {
+    expect(BaseZ.safeParse(validBase).success).toBe(true);
+  });
+
+  it('rejects id with wrong length', () => {
+    expect(BaseZ.safeParse({ ...validBase, id: 'short' }).success).toBe(false);
+  });
+});
+
+describe('UserSettingsZ', () => {
+  it('applies defaults for missing fields', () => {
+    const result = UserSettingsZ.parse({});
+    expect(result.colorfulPicks).toBe(true);
+    expect(result.hideFromLatestPicks).toBe(false);
+  });
+
+  it('accepts explicit values', () => {
+    const result = UserSettingsZ.parse({ colorfulPicks: false, hideFromLatestPicks: true });
+    expect(result.colorfulPicks).toBe(false);
+    expect(result.hideFromLatestPicks).toBe(true);
+  });
+});
+
+describe('UserZ', () => {
+  const validUser = {
+    ...validBase,
+    email: 'test@example.com',
+    username: 'testuser',
+    avatar: 'avatar.png',
+    bio: 'hello',
+  };
+
+  it('accepts a valid user', () => {
+    expect(UserZ.safeParse(validUser).success).toBe(true);
+  });
+
+  it('rejects invalid email', () => {
+    expect(UserZ.safeParse({ ...validUser, email: 'not-email' }).success).toBe(false);
+  });
+
+  it('accepts optional avatar_url', () => {
+    const withUrl = { ...validUser, avatar_url: 'https://example.com/pic.png' };
+    expect(UserZ.safeParse(withUrl).success).toBe(true);
+  });
+
+  it('accepts missing avatar_url', () => {
+    expect(UserZ.safeParse(validUser).success).toBe(true);
+  });
+
+  it('accepts null settings', () => {
+    const result = UserZ.parse({ ...validUser, settings: null });
+    expect(result.settings).toBeNull();
+  });
+});
+
+describe('StatZ', () => {
+  it('accepts valid stats', () => {
+    const stat = { user: '123456789012345', total_picks: 10, win_picks: 6, lose_picks: 4, win_loss_ratio: 1.5, win_pick_rate: 60 };
+    expect(StatZ.safeParse(stat).success).toBe(true);
+  });
+
+  it('allows null win_loss_ratio and win_pick_rate', () => {
+    const stat = { user: '123456789012345', total_picks: 0, win_picks: 0, lose_picks: 0, win_loss_ratio: null, win_pick_rate: null };
+    expect(StatZ.safeParse(stat).success).toBe(true);
+  });
+
+  it('rejects negative picks', () => {
+    const stat = { user: '123456789012345', total_picks: -1, win_picks: 0, lose_picks: 0, win_loss_ratio: null, win_pick_rate: null };
+    expect(StatZ.safeParse(stat).success).toBe(false);
+  });
+
+  it('rejects win_pick_rate above 100', () => {
+    const stat = { user: '123456789012345', total_picks: 0, win_picks: 0, lose_picks: 0, win_loss_ratio: null, win_pick_rate: 101 };
+    expect(StatZ.safeParse(stat).success).toBe(false);
+  });
+});
+
+describe('WeeklyStatZ', () => {
+  it('accepts valid year_week format', () => {
+    const stat = { user: '123456789012345', total_picks: 5, win_picks: 3, lose_picks: 2, win_loss_ratio: 1.5, win_pick_rate: 60, year_week: '2025-W01' };
+    expect(WeeklyStatZ.safeParse(stat).success).toBe(true);
+  });
+
+  it('rejects invalid year_week format', () => {
+    const stat = { user: '123456789012345', total_picks: 5, win_picks: 3, lose_picks: 2, win_loss_ratio: 1.5, win_pick_rate: 60, year_week: '2025-01' };
+    expect(WeeklyStatZ.safeParse(stat).success).toBe(false);
+  });
+});
+
+describe('MatchupZ', () => {
+  const validMatchup = {
+    ...validBase,
+    code: '123456789012345',
+    time_utc: '2025-01-15T00:00:00Z',
+    home_code: 'BOS',
+    away_code: 'NYK',
+    home_meta: { wins: 30, losses: 10 },
+    away_meta: { wins: 25, losses: 15 },
+    scoreboard: '123456789012345',
+  };
+
+  it('accepts a valid matchup', () => {
+    expect(MatchupZ.safeParse(validMatchup).success).toBe(true);
+  });
+
+  it('accepts null meta', () => {
+    expect(MatchupZ.safeParse({ ...validMatchup, home_meta: null, away_meta: null }).success).toBe(true);
+  });
+
+  it('accepts empty scoreboard', () => {
+    expect(MatchupZ.safeParse({ ...validMatchup, scoreboard: '' }).success).toBe(true);
+  });
+
+  it('rejects wrong team code length', () => {
+    expect(MatchupZ.safeParse({ ...validMatchup, home_code: 'BOST' }).success).toBe(false);
+  });
+});
+
+describe('ScoreboardZ', () => {
+  const validScoreboard = {
+    ...validBase,
+    code: '123456789012345',
+    status: 1,
+    status_text: '7:30 PM ET',
+    home_score: 50,
+    away_score: 45,
+  };
+
+  it('accepts a valid scoreboard', () => {
+    expect(ScoreboardZ.safeParse(validScoreboard).success).toBe(true);
+  });
+
+  it('rejects status outside 0-3', () => {
+    expect(ScoreboardZ.safeParse({ ...validScoreboard, status: 4 }).success).toBe(false);
+    expect(ScoreboardZ.safeParse({ ...validScoreboard, status: -1 }).success).toBe(false);
+  });
+
+  it('rejects negative scores', () => {
+    expect(ScoreboardZ.safeParse({ ...validScoreboard, home_score: -1 }).success).toBe(false);
+  });
+});
+
+describe('PickZ', () => {
+  const validPick = {
+    ...validBase,
+    matchup: '123456789012345',
+    win_prediction: 'BOS',
+    comment: 'Going with the home team',
+    user: '123456789012345',
+    status: 'upcoming',
+    result: '',
+  };
+
+  it('accepts a valid pick', () => {
+    expect(PickZ.safeParse(validPick).success).toBe(true);
+  });
+
+  it('rejects wrong matchup length', () => {
+    expect(PickZ.safeParse({ ...validPick, matchup: 'short' }).success).toBe(false);
+  });
+
+  it('rejects wrong win_prediction length', () => {
+    expect(PickZ.safeParse({ ...validPick, win_prediction: 'BOST' }).success).toBe(false);
+  });
+});
+
+describe('ReactionZ', () => {
+  it('accepts valid reaction', () => {
+    expect(ReactionZ.safeParse({ user: '123456789012345', pick: '123456789012345' }).success).toBe(true);
+  });
+
+  it('rejects wrong id length', () => {
+    expect(ReactionZ.safeParse({ user: 'abc', pick: '123456789012345' }).success).toBe(false);
+  });
+});
+
+describe('GameZ', () => {
+  const validMatchup = {
+    ...validBase,
+    code: '123456789012345',
+    time_utc: '2025-01-15T00:00:00Z',
+    home_code: 'BOS',
+    away_code: 'NYK',
+    home_meta: null,
+    away_meta: null,
+    scoreboard: '',
+  };
+
+  it('accepts a valid game', () => {
+    const game = { matchup: validMatchup, picks: [] };
+    expect(GameZ.safeParse(game).success).toBe(true);
+  });
+
+  it('accepts optional scoreboard', () => {
+    const scoreboard = { ...validBase, code: '123456789012345', status: 2, status_text: 'Q2', home_score: 50, away_score: 45 };
+    const game = { matchup: validMatchup, scoreboard, picks: [] };
+    expect(GameZ.safeParse(game).success).toBe(true);
+  });
+});

--- a/next-app/__tests__/lib/nba-scoreboard-utils.test.ts
+++ b/next-app/__tests__/lib/nba-scoreboard-utils.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import {
+  transformNBAGameToScoreboard,
+  transformNBAGamesToScoreboards,
+  findScoreboardByCode,
+} from '@/lib/nba-scoreboard-utils';
+import type { Game } from '@/lib/types/nba-scoreboards';
+
+function makeGame(overrides: Partial<Game> = {}): Game {
+  return {
+    gameCode: '0022400001',
+    gameStatus: 1,
+    gameStatusText: '7:30 PM ET',
+    homeTeam: {
+      teamTricode: 'BOS',
+      score: 0,
+    },
+    awayTeam: {
+      teamTricode: 'NYK',
+      score: 0,
+    },
+    ...overrides,
+  } as Game;
+}
+
+describe('transformNBAGameToScoreboard', () => {
+  it('transforms a valid game to a scoreboard', () => {
+    const game = makeGame();
+    const result = transformNBAGameToScoreboard(game);
+
+    expect(result).not.toBeNull();
+    expect(result!.code).toBe('0022400001');
+    expect(result!.status).toBe(1);
+    expect(result!.status_text).toBe('7:30 PM ET');
+    expect(result!.home_score).toBe(0);
+    expect(result!.away_score).toBe(0);
+  });
+
+  it('returns null if gameCode is missing', () => {
+    const game = makeGame({ gameCode: undefined } as Partial<Game>);
+    const result = transformNBAGameToScoreboard(game as Game);
+    expect(result).toBeNull();
+  });
+
+  it('returns null if gameStatus is not a number', () => {
+    const game = makeGame({ gameStatus: undefined } as Partial<Game>);
+    const result = transformNBAGameToScoreboard(game as Game);
+    expect(result).toBeNull();
+  });
+
+  it('clamps scores to non-negative', () => {
+    const game = makeGame({
+      homeTeam: { teamTricode: 'BOS', score: -5 },
+      awayTeam: { teamTricode: 'NYK', score: -10 },
+    } as Partial<Game>);
+    const result = transformNBAGameToScoreboard(game as Game);
+
+    expect(result).not.toBeNull();
+    expect(result!.home_score).toBe(0);
+    expect(result!.away_score).toBe(0);
+  });
+
+  it('clamps status to valid range (0-3)', () => {
+    const highStatus = makeGame({ gameStatus: 5 } as Partial<Game>);
+    const result = transformNBAGameToScoreboard(highStatus as Game);
+    expect(result!.status).toBe(3);
+
+    const lowStatus = makeGame({ gameStatus: -1 } as Partial<Game>);
+    const lowResult = transformNBAGameToScoreboard(lowStatus as Game);
+    expect(lowResult!.status).toBe(0);
+  });
+
+  it('defaults scores to 0 when teams are missing', () => {
+    const game = makeGame({ homeTeam: undefined, awayTeam: undefined } as Partial<Game>);
+    const result = transformNBAGameToScoreboard(game as Game);
+
+    expect(result).not.toBeNull();
+    expect(result!.home_score).toBe(0);
+    expect(result!.away_score).toBe(0);
+  });
+
+  it('trims status text and defaults to empty string', () => {
+    const withSpaces = makeGame({ gameStatusText: '  Q1 2:30  ' });
+    expect(transformNBAGameToScoreboard(withSpaces)!.status_text).toBe('Q1 2:30');
+
+    const noText = makeGame({ gameStatusText: undefined } as Partial<Game>);
+    expect(transformNBAGameToScoreboard(noText as Game)!.status_text).toBe('');
+  });
+
+  it('includes placeholder id, created, updated fields', () => {
+    const result = transformNBAGameToScoreboard(makeGame());
+    expect(result).toHaveProperty('id', '');
+    expect(result).toHaveProperty('created');
+    expect(result).toHaveProperty('updated');
+  });
+});
+
+describe('transformNBAGamesToScoreboards', () => {
+  it('transforms multiple valid games', () => {
+    const games = [
+      makeGame({ gameCode: '001' }),
+      makeGame({ gameCode: '002' }),
+    ];
+    const result = transformNBAGamesToScoreboards(games as Game[]);
+    expect(result).toHaveLength(2);
+    expect(result[0].code).toBe('001');
+    expect(result[1].code).toBe('002');
+  });
+
+  it('filters out invalid games', () => {
+    const games = [
+      makeGame({ gameCode: '001' }),
+      makeGame({ gameCode: undefined } as Partial<Game>),
+      makeGame({ gameCode: '003' }),
+    ];
+    const result = transformNBAGamesToScoreboards(games as Game[]);
+    expect(result).toHaveLength(2);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(transformNBAGamesToScoreboards([])).toEqual([]);
+  });
+});
+
+describe('findScoreboardByCode', () => {
+  const scoreboards = [
+    { id: '1', created: '', updated: '', code: '001', status: 1, status_text: '', home_score: 0, away_score: 0 },
+    { id: '2', created: '', updated: '', code: '002', status: 2, status_text: '', home_score: 10, away_score: 5 },
+  ];
+
+  it('finds a scoreboard by code', () => {
+    expect(findScoreboardByCode(scoreboards, '001')).toBe(scoreboards[0]);
+  });
+
+  it('returns null when code not found', () => {
+    expect(findScoreboardByCode(scoreboards, '999')).toBeNull();
+  });
+
+  it('returns null for empty array', () => {
+    expect(findScoreboardByCode([], '001')).toBeNull();
+  });
+});

--- a/next-app/__tests__/lib/utils.test.ts
+++ b/next-app/__tests__/lib/utils.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { cn, getUserAvatarUrl } from '@/lib/utils';
+
+describe('cn', () => {
+  it('merges class names', () => {
+    expect(cn('foo', 'bar')).toBe('foo bar');
+  });
+
+  it('handles conditional classes', () => {
+    expect(cn('base', false && 'hidden', 'visible')).toBe('base visible');
+  });
+
+  it('merges tailwind conflicts (last wins)', () => {
+    expect(cn('px-2', 'px-4')).toBe('px-4');
+  });
+
+  it('handles undefined and null inputs', () => {
+    expect(cn('base', undefined, null, 'end')).toBe('base end');
+  });
+});
+
+describe('getUserAvatarUrl', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns null when filename is empty', () => {
+    process.env.POCKETBASE_PUBLIC_URL = 'http://localhost:8090';
+    expect(getUserAvatarUrl('user123', '')).toBeNull();
+  });
+
+  it('returns null when userId is empty', () => {
+    process.env.POCKETBASE_PUBLIC_URL = 'http://localhost:8090';
+    expect(getUserAvatarUrl('', 'avatar.png')).toBeNull();
+  });
+
+  it('returns null when POCKETBASE_PUBLIC_URL is not set', () => {
+    delete process.env.POCKETBASE_PUBLIC_URL;
+    delete process.env.NEXT_PUBLIC_POCKETBASE_PUBLIC_URL;
+    expect(getUserAvatarUrl('user123', 'avatar.png')).toBeNull();
+  });
+
+  it('constructs correct avatar URL', () => {
+    process.env.POCKETBASE_PUBLIC_URL = 'http://localhost:8090';
+    const result = getUserAvatarUrl('user123', 'avatar.png');
+    expect(result).toBe('http://localhost:8090/api/files/users/user123/avatar.png');
+  });
+
+  it('falls back to NEXT_PUBLIC_POCKETBASE_PUBLIC_URL', () => {
+    delete process.env.POCKETBASE_PUBLIC_URL;
+    process.env.NEXT_PUBLIC_POCKETBASE_PUBLIC_URL = 'https://pb.example.com';
+    const result = getUserAvatarUrl('abc', 'pic.jpg');
+    expect(result).toBe('https://pb.example.com/api/files/users/abc/pic.jpg');
+  });
+});

--- a/next-app/app/actions/scoreboards.ts
+++ b/next-app/app/actions/scoreboards.ts
@@ -1,12 +1,14 @@
 'use server';
 
 import type { ScoreboardType } from '@/lib/definitions';
+import { ScoreboardZ } from '@/lib/definitions';
 import { fetchNBAScoreboardsEndpoint } from '@/lib/nba';
 import {
   transformNBAGamesToScoreboards,
   findScoreboardByCode,
 } from '@/lib/nba-scoreboard-utils';
 import { getLogger } from '@/lib/logger';
+import { getAdminPocketBase } from '@/lib/pocketbase-server';
 
 const logger = getLogger('scoreboards');
 
@@ -87,28 +89,81 @@ export async function getTodayScoreboards(): Promise<ScoreboardType[]> {
 }
 
 /**
- * Fetches scoreboards for a given code prefix (date code) from the NBA API
- * Filters scoreboards that match the prefix
+ * Fetches scoreboards for a given code prefix from the PocketBase database
+ */
+async function getScoreboardsFromDatabase(
+  codePrefix: string
+): Promise<ScoreboardType[]> {
+  const pb = await getAdminPocketBase();
+
+  try {
+    const records = await pb.collection('scoreboards').getFullList({
+      filter: pb.filter(`code ?~ {:codePrefix}`, { codePrefix }),
+    });
+
+    const scoreboards: ScoreboardType[] = [];
+    for (const record of records) {
+      const parsed = ScoreboardZ.safeParse(record);
+      if (parsed.success) {
+        scoreboards.push(parsed.data);
+      } else {
+        logger.warn(
+          { codePrefix, errors: parsed.error.issues },
+          'Scoreboard validation failed'
+        );
+      }
+    }
+
+    logger.debug(
+      { codePrefix, count: scoreboards.length },
+      'Fetched scoreboards from database'
+    );
+    return scoreboards;
+  } catch (error) {
+    logger.error(
+      {
+        codePrefix,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      'Failed to fetch scoreboards from database'
+    );
+    return [];
+  }
+}
+
+/**
+ * Fetches scoreboards for a given code prefix (date code)
+ * Queries PocketBase database first, falls back to NBA API for today's games
  */
 export async function getScoreboardsByCodePrefix(
   codePrefix: string
 ): Promise<ScoreboardType[]> {
   logger.debug(
     { codePrefix },
-    'Fetching scoreboards by code prefix from NBA API'
+    'Fetching scoreboards by code prefix'
   );
 
   try {
-    const allScoreboards = await getTodayScoreboards();
+    // Query database first (has historical scoreboards)
+    const dbScoreboards = await getScoreboardsFromDatabase(codePrefix);
 
-    // Filter scoreboards that match the code prefix
+    if (dbScoreboards.length > 0) {
+      logger.debug(
+        { codePrefix, count: dbScoreboards.length },
+        'Returning scoreboards from database'
+      );
+      return dbScoreboards;
+    }
+
+    // Fall back to NBA API for today/future dates not yet in DB
+    const allScoreboards = await getTodayScoreboards();
     const filtered = allScoreboards.filter((sb) =>
       sb.code.startsWith(codePrefix)
     );
 
     logger.debug(
       { codePrefix, count: filtered.length },
-      'Filtered scoreboards by code prefix'
+      'Filtered scoreboards from NBA API'
     );
 
     return filtered;

--- a/next-app/vite.config.ts
+++ b/next-app/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    include: ['__tests__/**/*.test.ts'],
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Fix `getScoreboardsByCodePrefix` to query PocketBase database first instead of only fetching from NBA API (which only returns today's games)
- Past dates now show final scores from database instead of defaulting to 'Upcoming' status
- Falls back to NBA API only for dates not yet in the database

## Root Cause
The NBA API endpoint (`todaysScoreboard_00.json`) only returns today's games. When navigating to a past date, no scoreboards were found, causing `scoreboard?.status || 0` to default to `0` (PreGame/Upcoming).

## Fix
Added `getScoreboardsFromDatabase()` helper that queries the `scoreboards` collection in PocketBase using the code prefix filter. The database already contains historical scoreboards populated by the cleanup cron job.

## Changes
- `next-app/app/actions/scoreboards.ts`: Added database query logic with NBA API fallback
