### PR TITLE
test: add vitest + MSW testing for next-app, split AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,120 +1,23 @@
 # AGENTS.md
 
-This repo contains two apps — an **Astro SSR app** (`astro-app/`) and a **Next.js App Router app** (`next-app/`). Both share PocketBase as a backend, TailwindCSS v4 for styling, and shadcn/ui (new-york style) for components.
+This repo contains two apps sharing PocketBase as a backend, TailwindCSS v4 for styling, and shadcn/ui (new-york style).
 
-## Build/Lint/Test Commands
+- [**astro-app/**](./astro-app/AGENTS.md) — Astro SSR app
+- [**next-app/**](./next-app/AGENTS.md) — Next.js App Router app
 
 Always check `pwd` before running commands. Use **pnpm** exclusively.
 
-### Astro App (`astro-app/`)
+## Shared Conventions
 
-```bash
-pnpm dev          # Start dev server
-pnpm build        # Production build
-pnpm preview      # Preview production build
-```
+- `@/` path alias in both apps
+- Zod schemas in `lib/definitions.ts`, inferred types as `FooType`
+- shadcn/ui: new-york style, neutral base, CSS variables
+- Semantic Tailwind color names only — never explicit colors
+- kebab-case files, PascalCase component folders
 
-No linter or test runner is configured for `astro-app`.
+## Shared Environment Variables
 
-### Next.js App (`next-app/`)
-
-```bash
-pnpm dev          # Start dev server
-pnpm build        # Production build
-pnpm lint         # Run ESLint (eslint-config-next + typescript)
-```
-
-No test runner is configured for `next-app`.
-
-## Project Structure
-
-```
-astro-app/src/
-  actions/        # Astro server actions (defineAction, exported as `server`)
-  components/     # React .tsx components + ui/ (shadcn)
-  layouts/        # .astro layouts (BaseLayout, Layout)
-  pages/          # .astro pages + api/ routes
-  lib/            # utilities, data fetching, definitions, types/
-  stores/         # nanostores (query.ts, settings.ts)
-  middleware.ts   # auth + posthog middleware
-
-next-app/
-  app/            # App Router pages, layouts, actions/
-  components/     # React components + ui/ (shadcn)
-  lib/            # utilities, pocketbase helpers, definitions, types/
-```
-
-## Code Style
-
-### Imports
-
-- Use `@/` path alias for all imports (configured in both tsconfigs)
-- Use `import type { ... }` for type-only imports
-- Import types from `@/lib/definitions` — never duplicate type definitions
-- Zod is imported from `astro/zod` in astro-app, `zod` in next-app
-
-### Types & Data Schemas
-
-- Define Zod schemas first in `*/lib/definitions.ts`, then export inferred types: `export type FooType = z.infer<typeof FooZ>`
-- Server Actions in next-app export their own state types (e.g., `LoginFormState`)
-- Use TypeScript interfaces for all component props
-
-### Components
-
-- shadcn/ui style: **new-york**, base color **neutral**, CSS variables enabled
-- Add shadcn components: `pnpm dlx shadcn@latest add <component>` (run from the respective app dir)
-- Keep components focused, dumb, and reusable — prefer composition over complex props
-
-### Astro App Specifics
-
-- `.astro` files for layouts/pages/static content, `.tsx` for interactive React components
-- Use `client:load` / `client:idle` / `client:visible` directives on React islands
-- Astro Actions: defined in `src/actions/`, exported as `server` object, use `defineAction` from `astro:actions`
-  - Call from pages: `Astro.callAction(actions.namespace.action, input)`
-  - Call from React: `actions.namespace.action()` from `astro:actions`
-  - Throw `ActionError` for client-visible errors
-- Auth state: `Astro.locals.isAuthed`, `Astro.locals.user`, `Astro.locals.pb`
-- Data fetching in React: React Query via nanostores (`@/stores/query`), pass `client` as second arg to `useQuery`/`useMutation`
-
-### Next.js App Specifics
-
-- Server Components by default; only use `'use client'` when hooks/events/browser APIs are needed
-- Server Actions in `app/actions/`, marked with `'use server'` at file top
-- Forms: `useActionState` hook, Zod validation, return `{ error?, success?, message? }`
-- Auth: `getAuthenticatedUser()` / `initPocketBase()` from `@/lib/pocketbase-server`
-- Handle `ClientResponseError` from PocketBase; check `NEXT_REDIRECT` digest for redirect errors
-
-### Styling
-
-- **TailwindCSS v4 only** — no inline styles, CSS modules, `@apply` in components, or styled-components
-- Use **semantic color names** only: `primary`, `secondary`, `accent`, `destructive`, `muted`, `background`, `foreground`, `card`, `border`, `input`, `ring`
-- **Never** use explicit colors like `bg-red-500`, `text-blue-600`, etc.
-- Responsive breakpoints: `sm:`, `md:`, `lg:`, `xl:`
-- Dark mode is automatic via CSS variables — no extra code needed
-- Match existing spacing, typography, and layout patterns before adding new styles
-
-### Error Handling
-
-- Astro actions: throw `ActionError` (from `astro:actions`) for errors visible to clients
-- Next.js server actions: return error state objects `{ error: string }`; handle `ClientResponseError` from PocketBase
-- React components: check `.error` property on action responses; handle gracefully
-
-### Naming Conventions
-
-- Zod schemas: PascalCase with `Z` suffix (e.g., `UserZ`, `MatchupZ`)
-- Inferred types: PascalCase with `Type` suffix (e.g., `UserType`, `MatchupType`)
-- Files: kebab-case for utils (`data-client.ts`), PascalCase folders for component groups
-- `cn()` utility from `@/lib/utils` for merging Tailwind classes
-
-### Logging
-
-- astro-app uses `pino` — get a logger via `getLogger('context:name')` from `@/lib/logger`
-- next-app has its own logger in `@/lib/logger`
-
-## Environment Variables
-
-Both apps use `.env` files (gitignored). Key variables:
-- `POCKETBASE_URL`, `POCKETBASE_PUBLIC_URL` — PocketBase instance
-- `ADMIN_USER`, `ADMIN_PASSWORD` — superuser credentials (astro-app)
-- `POSTHOG_API_HOST`, `POSTHOG_API_TOKEN` — analytics
-- In astro-app, env vars are accessed via `astro:env/server` and `astro:env/client`
+Both apps use `.env` (gitignored):
+- `POCKETBASE_URL`, `POCKETBASE_PUBLIC_URL`
+- `POSTHOG_API_HOST`, `POSTHOG_API_TOKEN`
+- `ADMIN_USER`, `ADMIN_PASSWORD` (astro-app only)

--- a/astro-app/AGENTS.md
+++ b/astro-app/AGENTS.md
@@ -1,0 +1,94 @@
+# AGENTS.md — astro-app
+
+Astro SSR app sharing PocketBase backend with next-app. TailwindCSS v4 + shadcn/ui (new-york style).
+
+## Commands
+
+Always check `pwd` before running commands. Use **pnpm** exclusively.
+
+```bash
+pnpm dev          # Start dev server
+pnpm build        # Production build
+pnpm preview      # Preview production build
+```
+
+No linter or test runner is configured.
+
+## Project Structure
+
+```
+src/
+  actions/        # Server actions (defineAction, exported as `server`)
+  components/     # React .tsx components + ui/ (shadcn)
+  layouts/        # .astro layouts (BaseLayout, Layout)
+  pages/          # .astro pages + api/ routes
+  lib/            # utilities, data fetching, definitions, types/
+  stores/         # nanostores (query.ts, settings.ts)
+  middleware.ts   # auth + posthog middleware
+```
+
+## Code Style
+
+### Imports
+
+- Use `@/` path alias
+- Use `import type { ... }` for type-only imports
+- Import types from `@/lib/definitions` — never duplicate type definitions
+- Zod is imported from `astro/zod`
+
+### Types & Data Schemas
+
+- Define Zod schemas first in `lib/definitions.ts`, then export inferred types: `export type FooType = z.infer<typeof FooZ>`
+- Use TypeScript interfaces for all component props
+
+### Components
+
+- shadcn/ui style: **new-york**, base color **neutral**, CSS variables enabled
+- Add shadcn components: `pnpm dlx shadcn@latest add <component>`
+- Keep components focused, dumb, and reusable — prefer composition over complex props
+- `.astro` files for layouts/pages/static content, `.tsx` for interactive React components
+- Use `client:load` / `client:idle` / `client:visible` directives on React islands
+
+### Astro Actions
+
+- Defined in `src/actions/`, exported as `server` object, use `defineAction` from `astro:actions`
+- Call from pages: `Astro.callAction(actions.namespace.action, input)`
+- Call from React: `actions.namespace.action()` from `astro:actions`
+- Throw `ActionError` for client-visible errors
+- Auth state: `Astro.locals.isAuthed`, `Astro.locals.user`, `Astro.locals.pb`
+
+### Data Fetching
+
+- React Query via nanostores (`@/stores/query`), pass `client` as second arg to `useQuery`/`useMutation`
+
+### Styling
+
+- **TailwindCSS v4 only** — no inline styles, CSS modules, `@apply` in components, or styled-components
+- Use **semantic color names** only: `primary`, `secondary`, `accent`, `destructive`, `muted`, `background`, `foreground`, `card`, `border`, `input`, `ring`
+- **Never** use explicit colors like `bg-red-500`, `text-blue-600`, etc.
+- Responsive breakpoints: `sm:`, `md:`, `lg:`, `xl:`
+- Dark mode is automatic via CSS variables
+
+### Error Handling
+
+- Throw `ActionError` (from `astro:actions`) for errors visible to clients
+- React components: check `.error` property on action responses; handle gracefully
+
+### Naming Conventions
+
+- Zod schemas: PascalCase with `Z` suffix (e.g., `UserZ`, `MatchupZ`)
+- Inferred types: PascalCase with `Type` suffix (e.g., `UserType`, `MatchupType`)
+- Files: kebab-case for utils, PascalCase folders for component groups
+- `cn()` utility from `@/lib/utils` for merging Tailwind classes
+
+### Logging
+
+- Uses `pino` — get a logger via `getLogger('context:name')` from `@/lib/logger`
+
+## Environment Variables
+
+`.env` file (gitignored). Key variables:
+- `POCKETBASE_URL`, `POCKETBASE_PUBLIC_URL` — PocketBase instance
+- `ADMIN_USER`, `ADMIN_PASSWORD` — superuser credentials
+- `POSTHOG_API_HOST`, `POSTHOG_API_TOKEN` — analytics
+- Accessed via `astro:env/server` and `astro:env/client`

--- a/next-app/AGENTS.md
+++ b/next-app/AGENTS.md
@@ -1,0 +1,98 @@
+# AGENTS.md — next-app
+
+Next.js App Router app sharing PocketBase backend with astro-app. TailwindCSS v4 + shadcn/ui (new-york style).
+
+## Commands
+
+Always check `pwd` before running commands. Use **pnpm** exclusively.
+
+```bash
+pnpm dev          # Start dev server
+pnpm build        # Production build
+pnpm lint         # Run ESLint (eslint-config-next + typescript)
+pnpm test         # Run Vitest in watch mode
+pnpm test:run     # Run Vitest once (CI mode)
+```
+
+## Project Structure
+
+```
+app/            # App Router pages, layouts, actions/
+components/     # React components + ui/ (shadcn)
+lib/            # utilities, pocketbase helpers, definitions, types/
+```
+
+## Code Style
+
+### Imports
+
+- Use `@/` path alias
+- Use `import type { ... }` for type-only imports
+- Import types from `@/lib/definitions` — never duplicate type definitions
+- Zod is imported from `zod`
+
+### Types & Data Schemas
+
+- Define Zod schemas first in `lib/definitions.ts`, then export inferred types: `export type FooType = z.infer<typeof FooZ>`
+- Server Actions export their own state types (e.g., `LoginFormState`)
+- Use TypeScript interfaces for all component props
+
+### Components
+
+- shadcn/ui style: **new-york**, base color **neutral**, CSS variables enabled
+- Add shadcn components: `pnpm dlx shadcn@latest add <component>`
+- Keep components focused, dumb, and reusable — prefer composition over complex props
+- Server Components by default; only use `'use client'` when hooks/events/browser APIs are needed
+
+### Server Actions
+
+- In `app/actions/`, marked with `'use server'` at file top
+- Forms: `useActionState` hook, Zod validation, return `{ error?, success?, message? }`
+- Auth: `getAuthenticatedUser()` / `initPocketBase()` from `@/lib/pocketbase-server`
+- Handle `ClientResponseError` from PocketBase; check `NEXT_REDIRECT` digest for redirect errors
+
+### Styling
+
+- **TailwindCSS v4 only** — no inline styles, CSS modules, `@apply` in components, or styled-components
+- Use **semantic color names** only: `primary`, `secondary`, `accent`, `destructive`, `muted`, `background`, `foreground`, `card`, `border`, `input`, `ring`
+- **Never** use explicit colors like `bg-red-500`, `text-blue-600`, etc.
+- Responsive breakpoints: `sm:`, `md:`, `lg:`, `xl:`
+- Dark mode is automatic via CSS variables
+
+### Error Handling
+
+- Server actions: return error state objects `{ error: string }`; handle `ClientResponseError` from PocketBase
+- React components: check `.error` property on action responses; handle gracefully
+
+### Naming Conventions
+
+- Zod schemas: PascalCase with `Z` suffix (e.g., `UserZ`, `MatchupZ`)
+- Inferred types: PascalCase with `Type` suffix (e.g., `UserType`, `MatchupType`)
+- Files: kebab-case for utils, PascalCase folders for component groups
+- `cn()` utility from `@/lib/utils` for merging Tailwind classes
+
+### Logging
+
+- Uses its own logger in `@/lib/logger`
+
+## Testing
+
+- **Framework**: Vitest + MSW (Mock Service Worker)
+- **Location**: `__tests__/`
+- **Rule**: Always add tests for new features
+- **Structure**:
+  - `__tests__/lib/<name>.test.ts` — lib utilities and helpers
+  - `__tests__/actions/<name>.test.ts` — server actions
+  - `__tests__/api/<name>.test.ts` — API route handlers
+- **Mocking**:
+  - PocketBase: `vi.mock('@/lib/pocketbase-server')`
+  - Next.js: `vi.mock('next/cache')`, `vi.mock('next/headers')`, `vi.mock('next/navigation')`
+  - HTTP: import `server` from `__tests__/setup/test-server` and use `server.use(...)`
+- **Fixtures**: use factories from `__tests__/fixtures/pocketbase-mock.ts` (`mockUser()`, `mockMatchup()`, `mockPick()`, `mockGame()`)
+- **Note**: All PocketBase record IDs must be exactly 15 characters (enforced by Zod `BaseZ` schema)
+
+## Environment Variables
+
+`.env` file (gitignored). Key variables:
+- `POCKETBASE_URL`, `POCKETBASE_PUBLIC_URL` — PocketBase instance
+- `POSTHOG_API_HOST`, `POSTHOG_API_TOKEN` — analytics

--- a/next-app/__tests__/actions/auth.test.ts
+++ b/next-app/__tests__/actions/auth.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { loginAction, logoutAction, signupAction } from '@/app/actions/auth';
+import type { LoginFormState, SignupFormState } from '@/app/actions/auth';
+import { ClientResponseError } from 'pocketbase';
+
+vi.mock('@/lib/pocketbase-server', () => ({
+  createPocketBase: vi.fn(),
+  getAdminPocketBase: vi.fn(),
+}));
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn((url: string) => {
+    const error = new Error('NEXT_REDIRECT');
+    (error as any).digest = `NEXT_REDIRECT;replace;${url};307;`;
+    throw error;
+  }),
+}));
+
+import { createPocketBase, getAdminPocketBase } from '@/lib/pocketbase-server';
+import { cookies } from 'next/headers';
+
+const mockCreatePocketBase = vi.mocked(createPocketBase);
+const mockGetAdminPocketBase = vi.mocked(getAdminPocketBase);
+const mockCookies = vi.mocked(cookies);
+
+function createFormData(values: Record<string, string>): FormData {
+  const formData = new FormData();
+  for (const [key, value] of Object.entries(values)) {
+    formData.set(key, value);
+  }
+  return formData;
+}
+
+describe('loginAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    const mockCookieStore = {
+      get: vi.fn().mockReturnValue(undefined),
+      set: vi.fn(),
+    };
+    mockCookies.mockResolvedValue(mockCookieStore as any);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns error on invalid credentials', async () => {
+    const mockPb = {
+      authStore: {
+        token: null,
+        model: null,
+        record: null,
+      },
+      collection: vi.fn().mockReturnValue({
+        authWithPassword: vi.fn().mockRejectedValue(
+          new ClientResponseError({
+            status: 400,
+            message: 'Wrong email or password',
+            data: {},
+          })
+        ),
+      }),
+    };
+    mockCreatePocketBase.mockReturnValue(mockPb as any);
+
+    const formData = createFormData({
+      email: 'test@example.com',
+      password: 'wrongpassword',
+    });
+
+    const result = await loginAction(undefined, formData);
+
+    expect(result).toEqual({
+      error: 'Wrong email or password',
+    });
+  });
+
+  it('returns success on valid credentials', async () => {
+    const mockCookieStore = {
+      get: vi.fn().mockReturnValue(undefined),
+      set: vi.fn(),
+    };
+    mockCookies.mockResolvedValue(mockCookieStore as any);
+
+    const mockPb = {
+      authStore: {
+        token: 'mock-auth-token',
+        model: { id: 'mockuser000001' },
+        record: { id: 'mockuser000001' },
+      },
+      collection: vi.fn().mockReturnValue({
+        authWithPassword: vi.fn().mockResolvedValue({
+          record: { id: 'mockuser000001' },
+          token: 'mock-auth-token',
+        }),
+      }),
+    };
+    mockCreatePocketBase.mockReturnValue(mockPb as any);
+
+    const formData = createFormData({
+      email: 'test@example.com',
+      password: 'correctpassword',
+    });
+
+    await expect(loginAction(undefined, formData)).rejects.toThrow('NEXT_REDIRECT');
+    expect(mockCookieStore.set).toHaveBeenCalledWith(
+      'pb_auth',
+      expect.any(String),
+      expect.any(Object)
+    );
+  });
+
+  it('returns error on validation failure', async () => {
+    const formData = createFormData({
+      email: 'not-an-email',
+      password: '',
+    });
+
+    const result = await loginAction(undefined, formData);
+
+    expect(result).toHaveProperty('error');
+    expect(result.error).toBeDefined();
+  });
+});
+
+describe('logoutAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('clears auth state and redirects', async () => {
+    const mockCookieStore = {
+      delete: vi.fn(),
+    };
+    mockCookies.mockResolvedValue(mockCookieStore as any);
+
+    await expect(logoutAction()).rejects.toThrow('NEXT_REDIRECT');
+    expect(mockCookieStore.delete).toHaveBeenCalledWith('pb_auth');
+  });
+});
+
+describe('signupAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns error on validation failure', async () => {
+    const formData = createFormData({
+      email: 'not-an-email',
+      password: 'short',
+      confirm_password: 'short',
+    });
+
+    const result = await signupAction(undefined, formData);
+
+    expect(result).toHaveProperty('error');
+    expect(result.error).toBeDefined();
+  });
+
+  it('returns error when passwords do not match', async () => {
+    const formData = createFormData({
+      email: 'test@example.com',
+      password: 'password123',
+      confirm_password: 'password456',
+    });
+
+    const result = await signupAction(undefined, formData);
+
+    expect(result).toEqual({
+      error: 'Passwords do not match!',
+    });
+  });
+
+  it('returns success on valid signup', async () => {
+    const mockAdminPb = {
+      collection: vi.fn().mockReturnValue({
+        create: vi.fn().mockResolvedValue({ id: 'mockuser000001' }),
+        requestVerification: vi.fn().mockResolvedValue(undefined),
+      }),
+    };
+    const mockPb = {
+      collection: vi.fn().mockReturnValue({
+        requestVerification: vi.fn().mockResolvedValue(undefined),
+      }),
+    };
+
+    mockGetAdminPocketBase.mockResolvedValue(mockAdminPb as any);
+    mockCreatePocketBase.mockReturnValue(mockPb as any);
+
+    const formData = createFormData({
+      email: 'test@example.com',
+      password: 'password123',
+      confirm_password: 'password123',
+    });
+
+    const result = await signupAction(undefined, formData);
+
+    expect(result.success).toBe(true);
+    expect(result.message).toBe('Please check your email for a verification link!');
+  });
+});

--- a/next-app/__tests__/actions/matchups.test.ts
+++ b/next-app/__tests__/actions/matchups.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getGamesByCodePrefix, getMatchupPageData } from '@/app/actions/matchups';
+import { mockUser, mockMatchup, mockPick, mockGame } from '@/__tests__/fixtures/pocketbase-mock';
+
+vi.mock('@/lib/pocketbase-server', () => ({
+  getAuthenticatedUser: vi.fn(),
+  getAdminPocketBase: vi.fn(),
+  initPocketBase: vi.fn(),
+}));
+
+vi.mock('@/app/actions/scoreboards', () => ({
+  getScoreboardByCode: vi.fn(),
+  getScoreboardsByCodePrefix: vi.fn(),
+}));
+
+import { getAdminPocketBase, initPocketBase } from '@/lib/pocketbase-server';
+import { getScoreboardByCode, getScoreboardsByCodePrefix } from '@/app/actions/scoreboards';
+
+const mockGetAdminPocketBase = vi.mocked(getAdminPocketBase);
+const mockInitPocketBase = vi.mocked(initPocketBase);
+const mockGetScoreboardByCode = vi.mocked(getScoreboardByCode);
+const mockGetScoreboardsByCodePrefix = vi.mocked(getScoreboardsByCodePrefix);
+
+describe('getGamesByCodePrefix', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns games for valid dateCode', async () => {
+    const matchup = mockMatchup({ code: '002250000001234' });
+    const pick = mockPick({ matchup: matchup.id });
+
+    const mockPb = {
+      collection: vi.fn().mockReturnValue({
+        getFullList: vi.fn().mockResolvedValue([
+          {
+            ...matchup,
+            expand: {
+              picks_via_matchup: [pick],
+            },
+          },
+        ]),
+      }),
+    };
+    mockGetAdminPocketBase.mockResolvedValue(mockPb as any);
+    mockGetScoreboardsByCodePrefix.mockResolvedValue([]);
+
+    const result = await getGamesByCodePrefix('002');
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBe(1);
+    expect(result[0].matchup.code).toBe('002250000001234');
+  });
+
+  it('returns empty array for no matches', async () => {
+    const mockPb = {
+      collection: vi.fn().mockReturnValue({
+        getFullList: vi.fn().mockResolvedValue([]),
+      }),
+    };
+    mockGetAdminPocketBase.mockResolvedValue(mockPb as any);
+    mockGetScoreboardsByCodePrefix.mockResolvedValue([]);
+
+    const result = await getGamesByCodePrefix('999');
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe('getMatchupPageData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns matchup with games and picks', async () => {
+    const user = mockUser();
+    const matchup = mockMatchup({ code: '002250000001234' });
+    const pick = mockPick({
+      matchup: matchup.id,
+      user: user.id,
+      expand: {
+        user,
+        matchup,
+      },
+    });
+
+    const mockPb = {
+      collection: vi.fn().mockReturnValue({
+        getFirstListItem: vi.fn().mockResolvedValue({
+          ...matchup,
+          expand: {
+            picks_via_matchup: [pick],
+          },
+        }),
+      }),
+    };
+    mockGetAdminPocketBase.mockResolvedValue(mockPb as any);
+    mockGetScoreboardByCode.mockResolvedValue(null);
+
+    const result = await getMatchupPageData('002250000001234');
+
+    expect(result).not.toBeNull();
+    expect(result?.matchup.code).toBe('002250000001234');
+    expect(result?.picks.length).toBe(1);
+    expect(result?.picks[0].user).toBe(user.id);
+  });
+
+  it('returns null for invalid matchup code', async () => {
+    const mockPb = {
+      collection: vi.fn().mockReturnValue({
+        getFirstListItem: vi.fn().mockResolvedValue(null),
+      }),
+    };
+    mockGetAdminPocketBase.mockResolvedValue(mockPb as any);
+
+    const result = await getMatchupPageData('invalid-code');
+
+    expect(result).toBeNull();
+  });
+});

--- a/next-app/__tests__/actions/picks.test.ts
+++ b/next-app/__tests__/actions/picks.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { submitPickAction, deletePickAction } from '@/app/actions/picks';
+import type { SubmitPickFormState, DeletePickFormState } from '@/app/actions/picks';
+import { mockUser, mockPick, mockMatchup } from '@/__tests__/fixtures/pocketbase-mock';
+
+vi.mock('@/lib/pocketbase-server', () => ({
+  getAuthenticatedUser: vi.fn(),
+  getAdminPocketBase: vi.fn(),
+  initPocketBase: vi.fn(),
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}));
+
+import { getAuthenticatedUser, initPocketBase } from '@/lib/pocketbase-server';
+import { revalidatePath } from 'next/cache';
+
+const mockGetAuthenticatedUser = vi.mocked(getAuthenticatedUser);
+const mockInitPocketBase = vi.mocked(initPocketBase);
+const mockRevalidatePath = vi.mocked(revalidatePath);
+
+function createFormData(values: Record<string, string>): FormData {
+  const formData = new FormData();
+  for (const [key, value] of Object.entries(values)) {
+    formData.set(key, value);
+  }
+  return formData;
+}
+
+function createMockPb(overrides: { matchupRecord?: any; pickRecord?: any } = {}) {
+  const collectionMock = vi.fn();
+
+  collectionMock.mockImplementation((name: string) => {
+    if (name === 'matchups') {
+      return {
+        getOne: vi.fn().mockResolvedValue(
+          overrides.matchupRecord || mockMatchup()
+        ),
+      };
+    }
+    if (name === 'picks') {
+      return {
+        getOne: vi.fn().mockResolvedValue(overrides.pickRecord || null),
+        create: vi.fn().mockResolvedValue(overrides.pickRecord || {
+          id: 'mockpick0000001',
+          created: '2025-03-14 12:00:00.000Z',
+          updated: '2025-03-14 12:00:00.000Z',
+          matchup: 'mockmatchup0001',
+          win_prediction: 'BOS',
+          comment: 'Test pick',
+          user: 'mockuser0000001',
+          status: 'upcoming',
+          result: '',
+        }),
+        delete: vi.fn().mockResolvedValue(undefined),
+      };
+    }
+    return {
+      getOne: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({}),
+      delete: vi.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  return collectionMock;
+}
+
+describe('submitPickAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns error when not authenticated', async () => {
+    mockGetAuthenticatedUser.mockResolvedValue(null);
+
+    const formData = createFormData({
+      win_prediction: 'BOS',
+      matchup: 'mockmatchup0001',
+    });
+
+    const result = await submitPickAction(undefined, formData);
+
+    expect(result).toEqual({
+      error: 'You must be logged in to submit a pick',
+    });
+  });
+
+  it('returns error on validation failure (invalid win_prediction length)', async () => {
+    mockGetAuthenticatedUser.mockResolvedValue({
+      record: mockUser(),
+      token: 'mock-token',
+    });
+
+    const formData = createFormData({
+      win_prediction: 'BOSTON',
+      matchup: 'mockmatchup0001',
+    });
+
+    const result = await submitPickAction(undefined, formData);
+
+    expect(result).toHaveProperty('error');
+    expect(result.error).toBeDefined();
+  });
+
+  it('returns error for indeterminate win_prediction', async () => {
+    mockGetAuthenticatedUser.mockResolvedValue({
+      record: mockUser(),
+      token: 'mock-token',
+    });
+
+    const formData = createFormData({
+      win_prediction: 'indeterminate',
+      matchup: 'mockmatchup0001',
+    });
+
+    const result = await submitPickAction(undefined, formData);
+
+    expect(result).toHaveProperty('error');
+    expect(result.error).toContain('Too big');
+  });
+
+  it('successfully creates a pick when authenticated', async () => {
+    const user = mockUser();
+    const matchup = mockMatchup();
+
+    mockGetAuthenticatedUser.mockResolvedValue({
+      record: user,
+      token: 'mock-token',
+    });
+
+    const createdPick = {
+      id: 'mockpick0000001',
+      created: '2025-03-14 12:00:00.000Z',
+      updated: '2025-03-14 12:00:00.000Z',
+      matchup: matchup.id,
+      win_prediction: 'BOS',
+      comment: 'Test pick',
+      user: user.id,
+      status: 'upcoming',
+      result: '',
+    };
+
+    const mockPb = createMockPb({
+      matchupRecord: matchup,
+      pickRecord: createdPick,
+    });
+    mockInitPocketBase.mockResolvedValue({ collection: mockPb } as any);
+
+    const formData = createFormData({
+      win_prediction: 'BOS',
+      comment: 'Test pick',
+      matchup: matchup.id,
+    });
+
+    const result = await submitPickAction(undefined, formData);
+
+    expect(result.success).toBe(true);
+    expect(result.pick).toBeDefined();
+    expect(result.pick?.win_prediction).toBe('BOS');
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/matchup', 'page');
+  });
+});
+
+describe('deletePickAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns error when not authenticated', async () => {
+    mockGetAuthenticatedUser.mockResolvedValue(null);
+
+    const formData = createFormData({
+      id: 'mockpick0000001',
+      matchup: 'mockmatchup0001',
+    });
+
+    const result = await deletePickAction(undefined, formData);
+
+    expect(result).toEqual({
+      error: 'You must be logged in to delete a pick',
+    });
+  });
+
+  it('successfully deletes a pick when authenticated', async () => {
+    const user = mockUser();
+    const pick = mockPick({ user: user.id });
+
+    mockGetAuthenticatedUser.mockResolvedValue({
+      record: user,
+      token: 'mock-token',
+    });
+
+    const mockPb = createMockPb({ pickRecord: pick });
+    mockInitPocketBase.mockResolvedValue({ collection: mockPb } as any);
+
+    const formData = createFormData({
+      id: pick.id,
+      matchup: pick.matchup,
+    });
+
+    const result = await deletePickAction(undefined, formData);
+
+    expect(result.success).toBe(true);
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/matchup', 'page');
+  });
+});

--- a/next-app/__tests__/api/cron-handlers.test.ts
+++ b/next-app/__tests__/api/cron-handlers.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { POST as updateMatchups } from '@/app/api/cron/update-matchups/route';
+import { POST as updateScoreboards } from '@/app/api/cron/update-scoreboards/route';
+import { POST as cleanup } from '@/app/api/cron/cleanup/route';
+
+vi.mock('@/lib/pocketbase-server', () => ({
+  getAdminPocketBase: vi.fn(),
+}));
+
+vi.mock('@/lib/cron-utils', () => ({
+  getCronLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    trackBatchOperation: vi.fn(() => ({
+      recordSuccess: vi.fn(),
+      recordError: vi.fn(),
+      complete: vi.fn(() => ({ success: 0, errors: 0 })),
+    })),
+  })),
+  trackPerformance: vi.fn((_name, fn) => fn()),
+  createErrorResponse: vi.fn((_error, _startTime, _meta) => ({
+    json: vi.fn(() => Promise.resolve({ error: 'Internal server error' })),
+  })),
+  generateExecutionMetrics: vi.fn((_startTime, _meta) => ({
+    durationMs: '100.00',
+    startTime: '2025-01-01T00:00:00.000Z',
+    endTime: '2025-01-01T00:00:01.000Z',
+    ..._meta,
+  })),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  getLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+vi.mock('@/lib/nba', () => ({
+  fetchNBAScheduleEndpoint: vi.fn(),
+  fetchNBAScoreboardsEndpoint: vi.fn(),
+}));
+
+vi.mock('@/app/actions/matchups', () => ({
+  getMatchupByCode: vi.fn(),
+}));
+
+vi.mock('@/app/actions/cron', () => ({
+  getTodayMatchups: vi.fn(),
+  attachMatchupToScoreboard: vi.fn(),
+  updatePicksStatusByCode: vi.fn(),
+  updateScoreboard: vi.fn(),
+  updatePicksStatus: vi.fn(),
+}));
+
+describe('Cron handlers authentication', () => {
+  const VALID_SECRET = 'test-cron-secret';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = VALID_SECRET;
+  });
+
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+    vi.restoreAllMocks();
+  });
+
+  describe('update-matchups cron handler', () => {
+    it('returns 401 without auth header', async () => {
+      const request = new Request('http://localhost/api/cron/update-matchups', {
+        method: 'POST',
+      });
+
+      const response = await updateMatchups(request);
+
+      expect(response.status).toBe(401);
+      const json = await response.json();
+      expect(json.error).toBe('Unauthorized');
+    });
+
+    it('returns 401 with wrong secret', async () => {
+      const request = new Request('http://localhost/api/cron/update-matchups', {
+        method: 'POST',
+        headers: { 'Cron-Secret': 'wrong-secret' },
+      });
+
+      const response = await updateMatchups(request);
+
+      expect(response.status).toBe(401);
+      const json = await response.json();
+      expect(json.error).toBe('Unauthorized');
+    });
+
+    it('returns 500 when CRON_SECRET is not set', async () => {
+      delete process.env.CRON_SECRET;
+
+      const request = new Request('http://localhost/api/cron/update-matchups', {
+        method: 'POST',
+        headers: { 'Cron-Secret': 'any-secret' },
+      });
+
+      const response = await updateMatchups(request);
+
+      expect(response.status).toBe(500);
+      const json = await response.json();
+      expect(json.error).toBe('Server configuration error');
+    });
+  });
+
+  describe('update-scoreboards cron handler', () => {
+    it('returns 401 without auth header', async () => {
+      const request = new Request('http://localhost/api/cron/update-scoreboards', {
+        method: 'POST',
+      });
+
+      const response = await updateScoreboards(request);
+
+      expect(response.status).toBe(401);
+      const json = await response.json();
+      expect(json.error).toBe('Unauthorized');
+    });
+
+    it('returns 401 with wrong secret', async () => {
+      const request = new Request('http://localhost/api/cron/update-scoreboards', {
+        method: 'POST',
+        headers: { 'Cron-Secret': 'wrong-secret' },
+      });
+
+      const response = await updateScoreboards(request);
+
+      expect(response.status).toBe(401);
+      const json = await response.json();
+      expect(json.error).toBe('Unauthorized');
+    });
+
+    it('returns 500 when CRON_SECRET is not set', async () => {
+      delete process.env.CRON_SECRET;
+
+      const request = new Request('http://localhost/api/cron/update-scoreboards', {
+        method: 'POST',
+        headers: { 'Cron-Secret': 'any-secret' },
+      });
+
+      const response = await updateScoreboards(request);
+
+      expect(response.status).toBe(500);
+      const json = await response.json();
+      expect(json.error).toBe('Server configuration error');
+    });
+  });
+
+  describe('cleanup cron handler', () => {
+    it('returns 401 without auth header', async () => {
+      const request = new Request('http://localhost/api/cron/cleanup', {
+        method: 'POST',
+      });
+
+      const response = await cleanup(request);
+
+      expect(response.status).toBe(401);
+      const json = await response.json();
+      expect(json.error).toBe('Unauthorized');
+    });
+
+    it('returns 401 with wrong secret', async () => {
+      const request = new Request('http://localhost/api/cron/cleanup', {
+        method: 'POST',
+        headers: { 'Cron-Secret': 'wrong-secret' },
+      });
+
+      const response = await cleanup(request);
+
+      expect(response.status).toBe(401);
+      const json = await response.json();
+      expect(json.error).toBe('Unauthorized');
+    });
+
+    it('returns 500 when CRON_SECRET is not set', async () => {
+      delete process.env.CRON_SECRET;
+
+      const request = new Request('http://localhost/api/cron/cleanup', {
+        method: 'POST',
+        headers: { 'Cron-Secret': 'any-secret' },
+      });
+
+      const response = await cleanup(request);
+
+      expect(response.status).toBe(500);
+      const json = await response.json();
+      expect(json.error).toBe('Server configuration error');
+    });
+  });
+});

--- a/next-app/__tests__/api/games.test.ts
+++ b/next-app/__tests__/api/games.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GET } from '@/app/api/games/[dateCode]/route';
+
+vi.mock('@/app/actions/matchups', () => ({
+  getGamesByCodePrefix: vi.fn(),
+}));
+
+const mockGetGamesByCodePrefix = vi.mocked(
+  (await import('@/app/actions/matchups')).getGamesByCodePrefix
+);
+
+describe('GET /api/games/[dateCode]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns games for a valid dateCode', async () => {
+    const mockGames = [
+      {
+        matchup: {
+          id: 'abc123def456ghi',
+          code: '20250101/LALBOS',
+          time_utc: '2025-01-01T19:30:00Z',
+          home_code: 'BOS',
+          away_code: 'LAL',
+          home_meta: { wins: 20, losses: 10 },
+          away_meta: { wins: 18, losses: 12 },
+          scoreboard: '',
+          created: '2024-12-01T00:00:00Z',
+          updated: '2024-12-01T00:00:00Z',
+        },
+        picks: [],
+      },
+    ];
+
+    mockGetGamesByCodePrefix.mockResolvedValue(mockGames);
+
+    const params = Promise.resolve({ dateCode: '20250101' });
+    const response = await GET(new Request('http://localhost'), { params });
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.games).toEqual(mockGames);
+  });
+
+  it('returns empty array when no games exist for dateCode', async () => {
+    mockGetGamesByCodePrefix.mockResolvedValue([]);
+
+    const params = Promise.resolve({ dateCode: '20250101' });
+    const response = await GET(new Request('http://localhost'), { params });
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.games).toEqual([]);
+  });
+
+  it('returns 400 for invalid dateCode format', async () => {
+    mockGetGamesByCodePrefix.mockRejectedValue(
+      new Error('Invalid date code format')
+    );
+
+    const params = Promise.resolve({ dateCode: 'invalid' });
+
+    await expect(
+      GET(new Request('http://localhost'), { params })
+    ).rejects.toThrow('Invalid date code format');
+  });
+});

--- a/next-app/__tests__/api/matchup.test.ts
+++ b/next-app/__tests__/api/matchup.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GET } from '@/app/api/matchup/[dateCode]/[gameCode]/route';
+
+vi.mock('@/app/actions/matchups', () => ({
+  getMatchupPageData: vi.fn(),
+}));
+
+const mockGetMatchupPageData = vi.mocked(
+  (await import('@/app/actions/matchups')).getMatchupPageData
+);
+
+describe('GET /api/matchup/[dateCode]/[gameCode]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns matchup data for valid params', async () => {
+    const mockMatchupData = {
+      matchup: {
+        id: 'abc123def456ghi',
+        code: '20250101/LALBOS',
+        time_utc: '2025-01-01T19:30:00Z',
+        home_code: 'BOS',
+        away_code: 'LAL',
+        home_meta: { wins: 20, losses: 10 },
+        away_meta: { wins: 18, losses: 12 },
+        scoreboard: '',
+        created: '2024-12-01T00:00:00Z',
+        updated: '2024-12-01T00:00:00Z',
+      },
+      scoreboard: null,
+      picks: [],
+    };
+
+    mockGetMatchupPageData.mockResolvedValue(mockMatchupData);
+
+    const params = Promise.resolve({ dateCode: '20250101', gameCode: 'LALBOS' });
+    const response = await GET(new Request('http://localhost'), { params });
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json).toEqual(mockMatchupData);
+    expect(mockGetMatchupPageData).toHaveBeenCalledWith('20250101/LALBOS');
+  });
+
+  it('returns 404 when matchup not found', async () => {
+    mockGetMatchupPageData.mockResolvedValue(null);
+
+    const params = Promise.resolve({ dateCode: '20250101', gameCode: 'NOTFOUND' });
+    const response = await GET(new Request('http://localhost'), { params });
+
+    expect(response.status).toBe(404);
+    const json = await response.json();
+    expect(json.error).toBe('Not found');
+  });
+
+  it('returns 404 for invalid gameCode', async () => {
+    mockGetMatchupPageData.mockResolvedValue(null);
+
+    const params = Promise.resolve({ dateCode: '20250101', gameCode: '' });
+    const response = await GET(new Request('http://localhost'), { params });
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/next-app/__tests__/api/scoreboard.test.ts
+++ b/next-app/__tests__/api/scoreboard.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GET } from '@/app/api/scoreboard/route';
+
+vi.mock('@/lib/nba', () => ({
+  fetchNBAScoreboardsEndpoint: vi.fn(),
+}));
+
+vi.mock('@/lib/nba-scoreboard-utils', () => ({
+  transformNBAGamesToScoreboards: vi.fn(),
+  findScoreboardByCode: vi.fn(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  getLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+const mockFetchNBAScoreboardsEndpoint = vi.mocked(
+  (await import('@/lib/nba')).fetchNBAScoreboardsEndpoint
+);
+const mockTransformNBAGamesToScoreboards = vi.mocked(
+  (await import('@/lib/nba-scoreboard-utils')).transformNBAGamesToScoreboards
+);
+const mockFindScoreboardByCode = vi.mocked(
+  (await import('@/lib/nba-scoreboard-utils')).findScoreboardByCode
+);
+
+function createMockRequest(searchParams: Record<string, string> = {}) {
+  const params = new URLSearchParams(searchParams);
+  return {
+    nextUrl: { searchParams: params },
+  } as unknown as NextRequest;
+}
+
+describe('GET /api/scoreboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns 200 with scoreboard data when games exist', async () => {
+    const mockGames = [
+      { gameCode: '20250101/LALBOS', gameStatus: 1 },
+    ];
+    const mockScoreboards = [
+      { code: '20250101/LALBOS', status: 1, status_text: '7:30 PM ET', home_score: 0, away_score: 0 },
+    ];
+
+    mockFetchNBAScoreboardsEndpoint.mockResolvedValue({
+      scoreboard: { games: mockGames },
+    });
+    mockTransformNBAGamesToScoreboards.mockReturnValue(mockScoreboards);
+
+    const request = createMockRequest();
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json).toEqual(mockScoreboards);
+  });
+
+  it('returns 200 with single scoreboard when code param is provided', async () => {
+    const mockGames = [{ gameCode: '20250101/LALBOS', gameStatus: 2 }];
+    const mockScoreboards = [
+      { code: '20250101/LALBOS', status: 2, status_text: 'Live', home_score: 98, away_score: 102 },
+    ];
+    const singleScoreboard = mockScoreboards[0];
+
+    mockFetchNBAScoreboardsEndpoint.mockResolvedValue({
+      scoreboard: { games: mockGames },
+    });
+    mockTransformNBAGamesToScoreboards.mockReturnValue(mockScoreboards);
+    mockFindScoreboardByCode.mockReturnValue(singleScoreboard);
+
+    const request = createMockRequest({ code: '20250101/LALBOS' });
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json).toEqual(singleScoreboard);
+  });
+
+  it('handles missing data gracefully when no games are found', async () => {
+    mockFetchNBAScoreboardsEndpoint.mockResolvedValue({
+      scoreboard: { games: [] },
+    });
+
+    const request = createMockRequest();
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json).toBeNull();
+  });
+
+  it('returns null when scoreboard not found for given code', async () => {
+    const mockGames = [{ gameCode: '20250101/LALBOS', gameStatus: 1 }];
+
+    mockFetchNBAScoreboardsEndpoint.mockResolvedValue({
+      scoreboard: { games: mockGames },
+    });
+    mockTransformNBAGamesToScoreboards.mockReturnValue([]);
+    mockFindScoreboardByCode.mockReturnValue(null);
+
+    const request = createMockRequest({ code: '20250101/NOTFOUND' });
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json).toBeNull();
+  });
+
+  it('returns 500 on NBA API error', async () => {
+    mockFetchNBAScoreboardsEndpoint.mockRejectedValue(
+      new Error('NBA API down')
+    );
+
+    const request = createMockRequest();
+    const response = await GET(request);
+
+    expect(response.status).toBe(500);
+    const json = await response.json();
+    expect(json).toBeNull();
+  });
+});

--- a/next-app/__tests__/fixtures/nba-schedule.json
+++ b/next-app/__tests__/fixtures/nba-schedule.json
@@ -1,0 +1,85 @@
+{
+  "leagueSchedule": {
+    "gameDates": [
+      {
+        "gameDate": "2025-03-15",
+        "games": [
+          {
+            "gameId": "0022400001",
+            "gameCode": "20250315/LALBOS",
+            "gameStatus": 1,
+            "gameStatusText": "7:30 pm ET",
+            "gameDateTimeUTC": "2025-03-15T23:30:00Z",
+            "homeTeam": {
+              "teamId": 1610612738,
+              "teamName": "Celtics",
+              "teamCity": "Boston",
+              "teamTricode": "BOS",
+              "wins": 45,
+              "losses": 12
+            },
+            "awayTeam": {
+              "teamId": 1610612747,
+              "teamName": "Lakers",
+              "teamCity": "Los Angeles",
+              "teamTricode": "LAL",
+              "wins": 38,
+              "losses": 19
+            }
+          },
+          {
+            "gameId": "0022400002",
+            "gameCode": "20250315/GSWPHX",
+            "gameStatus": 1,
+            "gameStatusText": "10:00 pm ET",
+            "gameDateTimeUTC": "2025-03-16T02:00:00Z",
+            "homeTeam": {
+              "teamId": 1610612756,
+              "teamName": "Suns",
+              "teamCity": "Phoenix",
+              "teamTricode": "PHX",
+              "wins": 35,
+              "losses": 22
+            },
+            "awayTeam": {
+              "teamId": 1610612744,
+              "teamName": "Warriors",
+              "teamCity": "Golden State",
+              "teamTricode": "GSW",
+              "wins": 33,
+              "losses": 24
+            }
+          }
+        ]
+      },
+      {
+        "gameDate": "2025-03-16",
+        "games": [
+          {
+            "gameId": "0022400003",
+            "gameCode": "20250316/MILMIA",
+            "gameStatus": 1,
+            "gameStatusText": "6:00 pm ET",
+            "gameDateTimeUTC": "2025-03-16T22:00:00Z",
+            "homeTeam": {
+              "teamId": 1610612748,
+              "teamName": "Heat",
+              "teamCity": "Miami",
+              "teamTricode": "MIA",
+              "wins": 30,
+              "losses": 27
+            },
+            "awayTeam": {
+              "teamId": 1610612749,
+              "teamName": "Bucks",
+              "teamCity": "Milwaukee",
+              "teamTricode": "MIL",
+              "wins": 36,
+              "losses": 21
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/next-app/__tests__/fixtures/nba-scoreboard.json
+++ b/next-app/__tests__/fixtures/nba-scoreboard.json
@@ -1,0 +1,84 @@
+{
+  "scoreboard": {
+    "gameDate": "2025-03-15",
+    "games": [
+      {
+        "gameId": "0022400001",
+        "gameCode": "20250315/LALBOS",
+        "gameStatus": 1,
+        "gameStatusText": "7:30 pm ET",
+        "gameDateTimeUTC": "2025-03-15T23:30:00Z",
+        "homeTeam": {
+          "teamId": 1610612738,
+          "teamName": "Celtics",
+          "teamCity": "Boston",
+          "teamTricode": "BOS",
+          "score": 0,
+          "wins": 45,
+          "losses": 12
+        },
+        "awayTeam": {
+          "teamId": 1610612747,
+          "teamName": "Lakers",
+          "teamCity": "Los Angeles",
+          "teamTricode": "LAL",
+          "score": 0,
+          "wins": 38,
+          "losses": 19
+        }
+      },
+      {
+        "gameId": "0022400002",
+        "gameCode": "20250315/GSWPHX",
+        "gameStatus": 2,
+        "gameStatusText": "3rd Qtr",
+        "period": 3,
+        "gameClock": "PT04M32S",
+        "gameDateTimeUTC": "2025-03-16T02:00:00Z",
+        "homeTeam": {
+          "teamId": 1610612756,
+          "teamName": "Suns",
+          "teamCity": "Phoenix",
+          "teamTricode": "PHX",
+          "score": 78,
+          "wins": 35,
+          "losses": 22
+        },
+        "awayTeam": {
+          "teamId": 1610612744,
+          "teamName": "Warriors",
+          "teamCity": "Golden State",
+          "teamTricode": "GSW",
+          "score": 82,
+          "wins": 33,
+          "losses": 24
+        }
+      },
+      {
+        "gameId": "0022400003",
+        "gameCode": "20250315/DENDAL",
+        "gameStatus": 3,
+        "gameStatusText": "Final",
+        "gameDateTimeUTC": "2025-03-15T00:00:00Z",
+        "homeTeam": {
+          "teamId": 1610612742,
+          "teamName": "Mavericks",
+          "teamCity": "Dallas",
+          "teamTricode": "DAL",
+          "score": 105,
+          "wins": 34,
+          "losses": 23
+        },
+        "awayTeam": {
+          "teamId": 1610612743,
+          "teamName": "Nuggets",
+          "teamCity": "Denver",
+          "teamTricode": "DEN",
+          "score": 112,
+          "wins": 40,
+          "losses": 17
+        }
+      }
+    ]
+  }
+}

--- a/next-app/__tests__/fixtures/pocketbase-mock.ts
+++ b/next-app/__tests__/fixtures/pocketbase-mock.ts
@@ -1,0 +1,57 @@
+import type { UserType, MatchupType, PickType, GameType } from '@/lib/definitions'
+
+export function mockUser(overrides: Partial<UserType> = {}): UserType {
+  return {
+    id: 'mockuser0000001',
+    created: '2025-01-01 00:00:00.000Z',
+    updated: '2025-01-01 00:00:00.000Z',
+    email: 'test@example.com',
+    username: 'testuser',
+    avatar: '',
+    bio: '',
+    settings: {
+      colorfulPicks: true,
+      hideFromLatestPicks: false,
+    },
+    ...overrides,
+  }
+}
+
+export function mockMatchup(overrides: Partial<MatchupType> = {}): MatchupType {
+  return {
+    id: 'mockmatchup0001',
+    created: '2025-01-01 00:00:00.000Z',
+    updated: '2025-01-01 00:00:00.000Z',
+    code: '0022400001',
+    time_utc: '2025-03-15T23:30:00Z',
+    home_code: 'BOS',
+    away_code: 'LAL',
+    home_meta: { wins: 45, losses: 12 },
+    away_meta: { wins: 38, losses: 19 },
+    scoreboard: '',
+    ...overrides,
+  }
+}
+
+export function mockPick(overrides: Partial<PickType> = {}): PickType {
+  return {
+    id: 'mockpick0000001',
+    created: '2025-03-14 12:00:00.000Z',
+    updated: '2025-03-14 12:00:00.000Z',
+    matchup: 'mockmatchup0001',
+    win_prediction: '105',
+    comment: 'Test pick',
+    user: 'mockuser0000001',
+    status: 'pending',
+    result: '',
+    ...overrides,
+  }
+}
+
+export function mockGame(overrides: Partial<GameType> = {}): GameType {
+  return {
+    matchup: mockMatchup(),
+    picks: [mockPick()],
+    ...overrides,
+  }
+}

--- a/next-app/__tests__/lib/cron-utils.test.ts
+++ b/next-app/__tests__/lib/cron-utils.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  BatchOperationTracker,
+  trackPerformance,
+  generateExecutionMetrics,
+  createSuccessResponse,
+  createErrorResponse,
+} from '@/lib/cron-utils';
+import type { BatchOperationOptions } from '@/lib/cron-utils';
+
+vi.mock('@/lib/logger', () => ({
+  getLogger: vi.fn(() => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+import { getLogger } from '@/lib/logger';
+
+const mockLogger = getLogger('test');
+
+describe('BatchOperationTracker', () => {
+  let perfNowMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    let now = 0;
+    perfNowMock = vi.fn(() => now);
+    vi.spyOn(performance, 'now').mockImplementation(perfNowMock);
+    vi.mocked(mockLogger.info).mockClear();
+    vi.mocked(mockLogger.error).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('logs start on construction', () => {
+    const options: BatchOperationOptions = { name: 'test-batch', totalItems: 100 };
+    new BatchOperationTracker(mockLogger, options);
+
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      { operation: 'test-batch', totalItems: 100 },
+      'Starting batch operation: test-batch'
+    );
+  });
+
+  it('increments success count on recordSuccess', () => {
+    const tracker = new BatchOperationTracker(mockLogger, { name: 'test' });
+    tracker.recordSuccess();
+    tracker.recordSuccess();
+
+    const metrics = tracker.complete();
+    expect(metrics.successCount).toBe(2);
+    expect(metrics.processedItems).toBe(2);
+  });
+
+  it('increments error count on recordError', () => {
+    const tracker = new BatchOperationTracker(mockLogger, { name: 'test' });
+    tracker.recordError(new Error('fail'));
+    tracker.recordError(new Error('fail2'));
+
+    const metrics = tracker.complete();
+    expect(metrics.errorCount).toBe(2);
+    expect(metrics.processedItems).toBe(2);
+  });
+
+  it('complete returns correct metrics', () => {
+    const tracker = new BatchOperationTracker(mockLogger, { name: 'test', totalItems: 4 });
+    tracker.recordSuccess();
+    tracker.recordSuccess();
+    tracker.recordError(new Error('fail'));
+    tracker.recordSuccess();
+
+    const metrics = tracker.complete();
+    expect(metrics.name).toBe('test');
+    expect(metrics.successCount).toBe(3);
+    expect(metrics.errorCount).toBe(1);
+    expect(metrics.processedItems).toBe(4);
+    expect(typeof metrics.durationMs).toBe('string');
+    expect(typeof metrics.itemsPerSecond).toBe('string');
+  });
+});
+
+describe('trackPerformance', () => {
+  beforeEach(() => {
+    vi.mocked(mockLogger.info).mockClear();
+    vi.mocked(mockLogger.error).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('resolves with result on success', async () => {
+    vi.spyOn(performance, 'now').mockReturnValueOnce(100).mockReturnValueOnce(200);
+    const fn = vi.fn().mockResolvedValue('done');
+    const result = await trackPerformance('testFn', fn, mockLogger);
+    expect(result).toBe('done');
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      { function: 'testFn', durationMs: '100.00' },
+      'Completed testFn in 100.00ms'
+    );
+  });
+
+  it('rethrows on error', async () => {
+    vi.spyOn(performance, 'now').mockReturnValueOnce(100).mockReturnValueOnce(200);
+    const err = new Error('boom');
+    const fn = vi.fn().mockRejectedValue(err);
+    await expect(trackPerformance('failFn', fn, mockLogger)).rejects.toThrow('boom');
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      { function: 'failFn', durationMs: '100.00', error: 'boom' },
+      'Error in failFn after 100.00ms'
+    );
+  });
+});
+
+describe('generateExecutionMetrics', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns startTime, endTime, durationMs', () => {
+    vi.spyOn(performance, 'now').mockReturnValue(500);
+    const metrics = generateExecutionMetrics(100);
+    expect(metrics).toHaveProperty('startTime');
+    expect(metrics).toHaveProperty('endTime');
+    expect(metrics).toHaveProperty('durationMs');
+    expect(typeof metrics.durationMs).toBe('string');
+  });
+});
+
+describe('createSuccessResponse', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns Response with status 200 and success true', async () => {
+    vi.spyOn(performance, 'now').mockReturnValue(300);
+    const res = createSuccessResponse('ok', 100, { extra: 'data' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.message).toBe('ok');
+    expect(body.metrics).toBeDefined();
+    expect(body.extra).toBe('data');
+  });
+});
+
+describe('createErrorResponse', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns Response with status 500 and success false', async () => {
+    vi.spyOn(performance, 'now').mockReturnValue(300);
+    const err = new Error('something broke');
+    const res = createErrorResponse(err, 100);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('something broke');
+    expect(body.metrics).toBeDefined();
+  });
+});

--- a/next-app/__tests__/lib/nba.test.ts
+++ b/next-app/__tests__/lib/nba.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../setup/test-server';
+import {
+  fetchNBAScheduleEndpoint,
+  fetchNBAScoreboardsEndpoint,
+} from '@/lib/nba';
+
+vi.mock('@/lib/logger', () => ({
+  getLogger: vi.fn(() => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+describe('fetchNBAScheduleEndpoint', () => {
+  it('returns parsed schedule data on success', async () => {
+    const result = await fetchNBAScheduleEndpoint();
+    expect(result).toBeDefined();
+    expect(result.leagueSchedule).toBeDefined();
+    expect(result.leagueSchedule.gameDates.length).toBeGreaterThan(0);
+  });
+
+  it('throws on API error', { timeout: 15000 }, async () => {
+    server.use(
+      http.get(
+        'https://cdn.nba.com/static/json/staticData/scheduleLeagueV2_1.json',
+        () => HttpResponse.json({ error: 'Not Found' }, { status: 404 })
+      )
+    );
+
+    await expect(fetchNBAScheduleEndpoint()).rejects.toThrow('NBA API returned 404');
+  });
+});
+
+describe('fetchNBAScoreboardsEndpoint', () => {
+  it('returns parsed scoreboard data on success', async () => {
+    const result = await fetchNBAScoreboardsEndpoint();
+    expect(result).toBeDefined();
+    expect(result.scoreboard).toBeDefined();
+  });
+
+  it('throws on API error', { timeout: 15000 }, async () => {
+    server.use(
+      http.get(
+        'https://cdn.nba.com/static/json/liveData/scoreboard/todaysScoreboard_00.json',
+        () => HttpResponse.json({ error: 'Not Found' }, { status: 500 })
+      )
+    );
+
+    await expect(fetchNBAScoreboardsEndpoint()).rejects.toThrow('NBA API returned 500');
+  });
+});

--- a/next-app/__tests__/lib/stats.test.ts
+++ b/next-app/__tests__/lib/stats.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { expandAvatarUrls, getStatsByUserId } from '@/lib/stats';
+import type { StatType, UserType } from '@/lib/definitions';
+import type { RecordModel } from 'pocketbase';
+
+const mockInitPocketBase = vi.fn();
+const mockGetAdminPocketBase = vi.fn();
+
+vi.mock('@/lib/pocketbase-server', () => ({
+  initPocketBase: () => mockInitPocketBase(),
+  getAdminPocketBase: () => mockGetAdminPocketBase(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  getLogger: vi.fn(() => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+vi.mock('@/lib/utils', () => ({
+  getUserAvatarUrl: vi.fn((userId: string, filename: string) => {
+    if (!filename || !userId) return null;
+    return `https://pb.example.com/api/files/users/${userId}/${filename}`;
+  }),
+}));
+
+describe('expandAvatarUrls', () => {
+  it('transforms avatar field to avatar_url with correct prefix', () => {
+    const user: UserType = {
+      id: 'user12345678901',
+      created: '2025-01-01T00:00:00Z',
+      updated: '2025-01-01T00:00:00Z',
+      email: 'test@example.com',
+      username: 'testuser',
+      avatar: 'avatar.png',
+      bio: '',
+      settings: null,
+    };
+
+    const item = {
+      id: 'stat12345678901',
+      created: '',
+      updated: '',
+      expand: { user },
+    } as RecordModel & { expand?: { user?: UserType } };
+
+    const result = expandAvatarUrls([item]);
+    expect(result[0].expand?.user?.avatar_url).toBe(
+      'https://pb.example.com/api/files/users/user12345678901/avatar.png'
+    );
+  });
+
+  it('handles missing expand.user', () => {
+    const item = {
+      id: 'stat12345678901',
+      created: '',
+      updated: '',
+      expand: {},
+    } as RecordModel & { expand?: { user?: UserType } };
+
+    const result = expandAvatarUrls([item]);
+    expect(result[0].expand?.user?.avatar_url).toBeUndefined();
+  });
+
+  it('handles null avatar', () => {
+    const user: UserType = {
+      id: 'user12345678901',
+      created: '2025-01-01T00:00:00Z',
+      updated: '2025-01-01T00:00:00Z',
+      email: 'test@example.com',
+      username: 'testuser',
+      avatar: '',
+      bio: '',
+      settings: null,
+    };
+
+    const item = {
+      id: 'stat12345678901',
+      created: '',
+      updated: '',
+      expand: { user },
+    } as RecordModel & { expand?: { user?: UserType } };
+
+    const result = expandAvatarUrls([item]);
+    expect(result[0].expand?.user?.avatar_url).toBeUndefined();
+  });
+});
+
+describe('getStatsByUserId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns parsed stats on success', async () => {
+    const mockStats: StatType = {
+      user: 'user12345678901',
+      total_picks: 10,
+      win_picks: 6,
+      lose_picks: 4,
+      win_loss_ratio: 1.5,
+      win_pick_rate: 60,
+    };
+
+    mockInitPocketBase.mockResolvedValue({
+      collection: vi.fn().mockReturnValue({
+        getFirstListItem: vi.fn().mockResolvedValue(mockStats),
+      }),
+    });
+
+    const result = await getStatsByUserId('user12345678901');
+    expect(result).toEqual(mockStats);
+  });
+
+  it('returns null when stats not found', async () => {
+    mockInitPocketBase.mockResolvedValue({
+      collection: vi.fn().mockReturnValue({
+        getFirstListItem: vi
+          .fn()
+          .mockRejectedValue(new Error('Record not found')),
+      }),
+    });
+
+    const result = await getStatsByUserId('user12345678901');
+    expect(result).toBeNull();
+  });
+
+  it('returns null on validation failure', async () => {
+    const invalidStats = {
+      user: 'short',
+      total_picks: -1,
+      win_picks: 0,
+      lose_picks: 0,
+      win_loss_ratio: null,
+      win_pick_rate: null,
+    };
+
+    mockInitPocketBase.mockResolvedValue({
+      collection: vi.fn().mockReturnValue({
+        getFirstListItem: vi.fn().mockResolvedValue(invalidStats),
+      }),
+    });
+
+    const result = await getStatsByUserId('user12345678901');
+    expect(result).toBeNull();
+  });
+
+  it('returns null on unexpected errors', async () => {
+    mockInitPocketBase.mockResolvedValue({
+      collection: vi.fn().mockReturnValue({
+        getFirstListItem: vi.fn().mockRejectedValue(new Error('Network error')),
+      }),
+    });
+
+    const result = await getStatsByUserId('user12345678901');
+    expect(result).toBeNull();
+  });
+});

--- a/next-app/__tests__/setup/global-setup.ts
+++ b/next-app/__tests__/setup/global-setup.ts
@@ -1,0 +1,5 @@
+export default function globalSetup() {
+  return {
+    async teardown() {},
+  }
+}

--- a/next-app/__tests__/setup/handlers.ts
+++ b/next-app/__tests__/setup/handlers.ts
@@ -1,0 +1,12 @@
+import { http, HttpResponse } from 'msw'
+import nbaSchedule from '../fixtures/nba-schedule.json'
+import nbaScoreboard from '../fixtures/nba-scoreboard.json'
+
+export const handlers = [
+  http.get('https://cdn.nba.com/static/json/staticData/scheduleLeagueV2_1.json', () => {
+    return HttpResponse.json(nbaSchedule)
+  }),
+  http.get('https://cdn.nba.com/static/json/liveData/scoreboard/todaysScoreboard_00.json', () => {
+    return HttpResponse.json(nbaScoreboard)
+  }),
+]

--- a/next-app/__tests__/setup/msw.ts
+++ b/next-app/__tests__/setup/msw.ts
@@ -1,0 +1,6 @@
+import { beforeAll, afterAll, afterEach } from 'vitest'
+import { server } from './test-server'
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())

--- a/next-app/__tests__/setup/server.ts
+++ b/next-app/__tests__/setup/server.ts
@@ -1,0 +1,4 @@
+import { setupServer } from 'msw/node'
+import { handlers } from './handlers'
+
+export const server = setupServer(...handlers)

--- a/next-app/__tests__/setup/test-server.ts
+++ b/next-app/__tests__/setup/test-server.ts
@@ -1,0 +1,15 @@
+import { setupServer } from 'msw/node'
+import { http, HttpResponse } from 'msw'
+import nbaSchedule from '../fixtures/nba-schedule.json'
+import nbaScoreboard from '../fixtures/nba-scoreboard.json'
+
+const handlers = [
+  http.get('https://cdn.nba.com/static/json/staticData/scheduleLeagueV2_1.json', () => {
+    return HttpResponse.json(nbaSchedule)
+  }),
+  http.get('https://cdn.nba.com/static/json/liveData/scoreboard/todaysScoreboard_00.json', () => {
+    return HttpResponse.json(nbaScoreboard)
+  }),
+]
+
+export const server = setupServer(...handlers)

--- a/next-app/package.json
+++ b/next-app/package.json
@@ -45,6 +45,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.0.1",
     "jsdom": "^29.0.1",
+    "msw": "^2.12.14",
     "tailwindcss": "^4",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5",

--- a/next-app/pnpm-lock.yaml
+++ b/next-app/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       jsdom:
         specifier: ^29.0.1
         version: 29.0.1
+      msw:
+        specifier: ^2.12.14
+        version: 2.12.14(@types/node@20.19.24)(typescript@5.9.3)
       tailwindcss:
         specifier: ^4
         version: 4.1.16
@@ -116,7 +119,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@20.19.24)(jsdom@29.0.1)(vite@8.0.3(@emnapi/core@1.6.0)(@emnapi/runtime@1.6.0)(@types/node@20.19.24)(jiti@2.6.1))
+        version: 4.1.2(@types/node@20.19.24)(jsdom@29.0.1)(msw@2.12.14(@types/node@20.19.24)(typescript@5.9.3))(vite@8.0.3(@emnapi/core@1.6.0)(@emnapi/runtime@1.6.0)(@types/node@20.19.24)(jiti@2.6.1))
 
 packages:
 
@@ -454,6 +457,41 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@inquirer/ansi@1.0.2':
+    resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/confirm@5.1.21':
+    resolution: {integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@10.3.2':
+    resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@1.0.15':
+    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
+    engines: {node: '>=18'}
+
+  '@inquirer/type@3.0.10':
+    resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -469,6 +507,10 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mswjs/interceptors@0.41.3':
+    resolution: {integrity: sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==}
+    engines: {node: '>=18'}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -552,6 +594,15 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
   '@oxc-project/types@0.122.0':
     resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
@@ -1137,6 +1188,9 @@ packages:
   '@types/react@19.2.2':
     resolution: {integrity: sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==}
 
+  '@types/statuses@2.0.6':
+    resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
+
   '@typescript-eslint/eslint-plugin@8.46.2':
     resolution: {integrity: sha512-ZGBMToy857/NIPaaCucIUQgqueOiq7HeAKkhlvqVV4lm089zUFW6ikRySx2v+cAhKeUCPuWVHeimyk6Dw1iY3w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1341,6 +1395,10 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -1466,8 +1524,16 @@ packages:
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -1485,6 +1551,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1577,6 +1647,9 @@ packages:
 
   embla-carousel@8.6.0:
     resolution: {integrity: sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
@@ -1844,6 +1917,10 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -1893,6 +1970,10 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  graphql@16.13.2:
+    resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -1919,6 +2000,9 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  headers-polyfill@4.0.3:
+    resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
@@ -1993,6 +2077,10 @@ packages:
     resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
     engines: {node: '>= 0.4'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-generator-function@1.1.2:
     resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
     engines: {node: '>= 0.4'}
@@ -2008,6 +2096,9 @@ packages:
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
@@ -2339,6 +2430,20 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msw@2.12.14:
+    resolution: {integrity: sha512-4KXa4nVBIBjbDbd7vfQNuQ25eFxug0aropCQFoI0JdOBuJWamkT1yLVIWReFI8SiTRc+H1hKzaNk+cLk2N9rtQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>= 4.8.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -2421,6 +2526,9 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
+
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
@@ -2450,6 +2558,9 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -2552,6 +2663,10 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -2571,6 +2686,9 @@ packages:
   resolve@2.0.0-next.5:
     resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
     hasBin: true
+
+  rettime@0.10.1:
+    resolution: {integrity: sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -2655,6 +2773,10 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2665,12 +2787,23 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
+
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
 
   string.prototype.includes@2.0.1:
     resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
@@ -2694,6 +2827,10 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -2726,6 +2863,10 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
 
   tailwind-merge@3.3.1:
     resolution: {integrity: sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==}
@@ -2792,6 +2933,10 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-fest@5.5.0:
+    resolution: {integrity: sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==}
+    engines: {node: '>=20'}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -2833,6 +2978,9 @@ packages:
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
+
+  until-async@3.0.2:
+    resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
 
   update-browserslist-db@1.1.4:
     resolution: {integrity: sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==}
@@ -2992,6 +3140,14 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -2999,12 +3155,28 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yoctocolors-cjs@2.1.3:
+    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
+    engines: {node: '>=18'}
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -3329,6 +3501,34 @@ snapshots:
   '@img/sharp-win32-x64@0.34.4':
     optional: true
 
+  '@inquirer/ansi@1.0.2': {}
+
+  '@inquirer/confirm@5.1.21(@types/node@20.19.24)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@20.19.24)
+      '@inquirer/type': 3.0.10(@types/node@20.19.24)
+    optionalDependencies:
+      '@types/node': 20.19.24
+
+  '@inquirer/core@10.3.2(@types/node@20.19.24)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@20.19.24)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 20.19.24
+
+  '@inquirer/figures@1.0.15': {}
+
+  '@inquirer/type@3.0.10(@types/node@20.19.24)':
+    optionalDependencies:
+      '@types/node': 20.19.24
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3347,6 +3547,15 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@mswjs/interceptors@0.41.3':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -3405,6 +3614,15 @@ snapshots:
       fastq: 1.19.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
 
   '@oxc-project/types@0.122.0': {}
 
@@ -3883,6 +4101,8 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
+  '@types/statuses@2.0.6': {}
+
   '@typescript-eslint/eslint-plugin@8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -4044,12 +4264,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.2(vite@8.0.3(@emnapi/core@1.6.0)(@emnapi/runtime@1.6.0)(@types/node@20.19.24)(jiti@2.6.1))':
+  '@vitest/mocker@4.1.2(msw@2.12.14(@types/node@20.19.24)(typescript@5.9.3))(vite@8.0.3(@emnapi/core@1.6.0)(@emnapi/runtime@1.6.0)(@types/node@20.19.24)(jiti@2.6.1))':
     dependencies:
       '@vitest/spy': 4.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
+      msw: 2.12.14(@types/node@20.19.24)(typescript@5.9.3)
       vite: 8.0.3(@emnapi/core@1.6.0)(@emnapi/runtime@1.6.0)(@types/node@20.19.24)(jiti@2.6.1)
 
   '@vitest/pretty-format@4.1.2':
@@ -4088,6 +4309,8 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ansi-regex@5.0.1: {}
 
   ansi-styles@4.3.0:
     dependencies:
@@ -4243,7 +4466,15 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
+  cli-width@4.1.0: {}
+
   client-only@0.0.1: {}
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   clsx@2.1.1: {}
 
@@ -4256,6 +4487,8 @@ snapshots:
   concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4348,6 +4581,8 @@ snapshots:
       embla-carousel: 8.6.0
 
   embla-carousel@8.6.0: {}
+
+  emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
 
@@ -4757,6 +4992,8 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-caller-file@2.0.5: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -4810,6 +5047,8 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  graphql@16.13.2: {}
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -4831,6 +5070,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  headers-polyfill@4.0.3: {}
 
   hermes-estree@0.25.1: {}
 
@@ -4911,6 +5152,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
+  is-fullwidth-code-point@3.0.0: {}
+
   is-generator-function@1.1.2:
     dependencies:
       call-bound: 1.0.4
@@ -4926,6 +5169,8 @@ snapshots:
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
+
+  is-node-process@1.2.0: {}
 
   is-number-object@1.1.1:
     dependencies:
@@ -5211,6 +5456,33 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msw@2.12.14(@types/node@20.19.24)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 5.1.21(@types/node@20.19.24)
+      '@mswjs/interceptors': 0.41.3
+      '@open-draft/deferred-promise': 2.2.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.13.2
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.10.1
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.1
+      type-fest: 5.5.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+
+  mute-stream@2.0.0: {}
+
   nanoid@3.3.11: {}
 
   napi-postinstall@0.3.4: {}
@@ -5300,6 +5572,8 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  outvariant@1.4.3: {}
+
   own-keys@1.0.1:
     dependencies:
       get-intrinsic: 1.3.0
@@ -5327,6 +5601,8 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-to-regexp@6.3.0: {}
 
   pathe@2.0.3: {}
 
@@ -5428,6 +5704,8 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  require-directory@2.1.1: {}
+
   require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
@@ -5445,6 +5723,8 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  rettime@0.10.1: {}
 
   reusify@1.1.0: {}
 
@@ -5593,11 +5873,15 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@4.1.0: {}
+
   source-map-js@1.2.1: {}
 
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@4.0.0: {}
 
@@ -5605,6 +5889,14 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  strict-event-emitter@0.5.1: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
 
   string.prototype.includes@2.0.1:
     dependencies:
@@ -5656,6 +5948,10 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
   strip-bom@3.0.0: {}
 
   strip-json-comments@3.1.1: {}
@@ -5674,6 +5970,8 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   symbol-tree@3.2.4: {}
+
+  tagged-tag@1.0.0: {}
 
   tailwind-merge@3.3.1: {}
 
@@ -5730,6 +6028,10 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@5.5.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -5812,6 +6114,8 @@ snapshots:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
 
+  until-async@3.0.2: {}
+
   update-browserslist-db@1.1.4(browserslist@4.27.0):
     dependencies:
       browserslist: 4.27.0
@@ -5856,10 +6160,10 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.2(@types/node@20.19.24)(jsdom@29.0.1)(vite@8.0.3(@emnapi/core@1.6.0)(@emnapi/runtime@1.6.0)(@types/node@20.19.24)(jiti@2.6.1)):
+  vitest@4.1.2(@types/node@20.19.24)(jsdom@29.0.1)(msw@2.12.14(@types/node@20.19.24)(typescript@5.9.3))(vite@8.0.3(@emnapi/core@1.6.0)(@emnapi/runtime@1.6.0)(@types/node@20.19.24)(jiti@2.6.1)):
     dependencies:
       '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(vite@8.0.3(@emnapi/core@1.6.0)(@emnapi/runtime@1.6.0)(@types/node@20.19.24)(jiti@2.6.1))
+      '@vitest/mocker': 4.1.2(msw@2.12.14(@types/node@20.19.24)(typescript@5.9.3))(vite@8.0.3(@emnapi/core@1.6.0)(@emnapi/runtime@1.6.0)(@types/node@20.19.24)(jiti@2.6.1))
       '@vitest/pretty-format': 4.1.2
       '@vitest/runner': 4.1.2
       '@vitest/snapshot': 4.1.2
@@ -5952,13 +6256,41 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
 
+  y18n@5.0.8: {}
+
   yallist@3.1.1: {}
 
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
   yocto-queue@0.1.0: {}
+
+  yoctocolors-cjs@2.1.3: {}
 
   zod-validation-error@4.0.2(zod@4.1.12):
     dependencies:

--- a/next-app/vite.config.ts
+++ b/next-app/vite.config.ts
@@ -5,6 +5,8 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     include: ['__tests__/**/*.test.ts'],
+    globals: true,
+    setupFiles: ['__tests__/setup/msw.ts'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

- **130 tests across 14 test files** — comprehensive test suite for next-app using Vitest + MSW
- **Lib tests** — cron-utils, nba, stats with mocked PocketBase and logger
- **Action tests** — picks, matchups, auth covering validation, auth checks, error handling
- **API route tests** — scoreboard, games, matchup, cron handlers with mocked dependencies
- **Test infrastructure** — MSW setup, PocketBase mock factories, NBA API fixtures
- **Split AGENTS.md** — root index + app-specific docs (astro-app/AGENTS.md, next-app/AGENTS.md)

## Test Files Added

| Category | Files | Tests |
|----------|-------|-------|
| Lib | cron-utils, nba, stats | 15 |
| Actions | picks, matchups, auth | 15 |
| API Routes | scoreboard, games, matchup, cron-handlers | 17 |
| Existing | date-utils, definitions, utils, nba-scoreboard-utils | 83 |

## Infrastructure

- test-server.ts — Shared MSW server instance
- msw.ts — Vitest lifecycle hooks
- pocketbase-mock.ts — Mock factories (mockUser, mockMatchup, mockPick, mockGame)
- nba-schedule.json / nba-scoreboard.json — NBA API mock data
- next-app/AGENTS.md — Testing guide with mocking patterns