### PR TITLE
feat: add vitest testing, user picks table, settings, and feedback system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,10 @@ Both apps use `.env` (gitignored):
 - `POCKETBASE_URL`, `POCKETBASE_PUBLIC_URL`
 - `POSTHOG_API_HOST`, `POSTHOG_API_TOKEN`
 - `ADMIN_USER`, `ADMIN_PASSWORD` (astro-app only)
+
+## Coolify Deployment
+
+- **Project UUID**: `x0cgcs0oos80csocwwcw8wk4`
+- **Environment UUID**: `u8wgw480wwwcsgockokkccko`
+- **Next App UUID**: `wck44k4s0o0coc0g04coock0` — http://lab.thestu.xyz:8000/project/x0cgcs0oos80csocwwcw8wk4/environment/u8wgw480wwwcsgockokkccko/application/wck44k4s0o0coc0g04coock0
+- **Astro App UUID**: `u800wskkwko0kggok44cko80` — http://lab.thestu.xyz:8000/project/x0cgcs0oos80csocwwcw8wk4/environment/u8wgw480wwwcsgockokkccko/application/u800wskkwko0kggok44cko80

--- a/next-app/components/profile/user-picks-table.tsx
+++ b/next-app/components/profile/user-picks-table.tsx
@@ -27,9 +27,9 @@ export function UserPicksTable({
   const upcomingPicks = picks.filter((p) => p.status === 'upcoming');
 
   const savedTab =
-    typeof window !== 'undefined' ? localStorage.getItem('userPicksTab') : null;
-  const initialTab = ['past', 'live', 'upcoming'].includes(savedTab || '')
-    ? savedTab
+    typeof window !== 'undefined' ? localStorage.getItem('userPicksTab') : undefined;
+  const initialTab = ['past', 'live', 'upcoming'].includes(savedTab ?? '')
+    ? (savedTab ?? defaultTab)
     : defaultTab;
 
   const handleTabChange = (value: string) => {


### PR DESCRIPTION
## Summary
- Add Vitest + MSW testing infrastructure with comprehensive test suites for lib utilities, server actions, and API routes
- Add user picks table component, settings page, latest picks carousel, and feedback system
- Split AGENTS.md into per-app docs with shared conventions
- Fix TypeScript error in `user-picks-table.tsx` (`null` vs `undefined` for Tabs `defaultValue`)
- Add Coolify deployment IDs to AGENTS.md