### PR TITLE
Replace picks carousel with Twitter-style vertical feed as homepage

### DIFF
--- a/next-app/app/games/page.tsx
+++ b/next-app/app/games/page.tsx
@@ -1,0 +1,33 @@
+import { getGamesByCodePrefix } from '@/app/actions/matchups';
+import { getTodayCodePrefix } from '@/lib/date-utils';
+import { GamesView } from '@/components/weekly/games-view';
+import { Card, CardContent } from '@/components/ui/card';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Games | Baller Picks',
+  description: 'View NBA matchups and games',
+};
+
+export default async function GamesPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ date?: string }>;
+}) {
+  const { date } = await searchParams;
+  const initialDateCode = date || getTodayCodePrefix();
+  const initialGames = await getGamesByCodePrefix(initialDateCode);
+
+  return (
+    <div className="container mx-auto px-0 sm:px-4 py-0 sm:py-4 max-w-6xl">
+      <Card>
+        <CardContent className="p-0">
+          <GamesView
+            initialDateCode={initialDateCode}
+            initialGames={initialGames}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/next-app/app/home/page.tsx
+++ b/next-app/app/home/page.tsx
@@ -1,43 +1,21 @@
-import { getGamesByCodePrefix } from '@/app/actions/matchups';
-import { getTodayCodePrefix } from '@/lib/date-utils';
-import { GamesView } from '@/components/weekly/games-view';
-import { Card, CardContent } from '@/components/ui/card';
 import { getLatestPicks } from '@/app/actions/picks';
 import { getAuthenticatedUser } from '@/lib/pocketbase-server';
 import { LatestPicksView } from '@/components/weekly/latest-picks-view';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Weekly Matchups | Baller Picks',
-  description: 'View NBA matchups for the week',
+  title: 'Latest Picks | Baller Picks',
+  description: 'See the latest picks from the community',
 };
 
-export default async function HomePage({
-  searchParams,
-}: {
-  searchParams: Promise<{ date?: string }>;
-}) {
-  const { date } = await searchParams;
-  const initialDateCode = date || getTodayCodePrefix();
-  const initialGames = await getGamesByCodePrefix(initialDateCode);
-
+export default async function HomePage() {
   const authUser = await getAuthenticatedUser();
   const { picks: latestPicks, users: latestPicksUsers } =
-    await getLatestPicks(10, authUser?.record.id);
+    await getLatestPicks(20, authUser?.record.id);
 
   return (
-    <div className="container mx-auto px-0 sm:px-4 py-0 sm:py-4 max-w-6xl">
-      {latestPicks.length > 0 && (
-        <LatestPicksView picks={latestPicks} users={latestPicksUsers} />
-      )}
-      <Card>
-        <CardContent className="p-0">
-          <GamesView
-            initialDateCode={initialDateCode}
-            initialGames={initialGames}
-          />
-        </CardContent>
-      </Card>
+    <div className="container mx-auto px-0 sm:px-4 py-0 sm:py-4 max-w-2xl">
+      <LatestPicksView picks={latestPicks} users={latestPicksUsers} />
     </div>
   );
 }

--- a/next-app/components/matchup/pick-slab.tsx
+++ b/next-app/components/matchup/pick-slab.tsx
@@ -21,8 +21,7 @@ interface PickSlabProps {
 export function PickSlab({ pick, user, matchupUrl }: PickSlabProps) {
   const teamCode = pick.win_prediction;
   const teamName = TeamMap[teamCode as keyof typeof TeamMap]?.name_short || teamCode;
-  
-  // Format relative time
+
   const createdAt = DateTime.fromISO(pick.created.replace(' ', 'T'))
     .toRelative({
       style: 'narrow',
@@ -35,7 +34,6 @@ export function PickSlab({ pick, user, matchupUrl }: PickSlabProps) {
     .replace(' ago', '')
     .trim();
 
-  // Fetch reactions using React Query
   const {
     data: reactionData,
     isLoading,
@@ -43,7 +41,6 @@ export function PickSlab({ pick, user, matchupUrl }: PickSlabProps) {
     enabled: !!pick.id,
   });
 
-  // Mutations for adding/removing reactions
   const addReactionMutation = useAddReaction();
   const removeReactionMutation = useRemoveReaction();
 
@@ -61,92 +58,72 @@ export function PickSlab({ pick, user, matchupUrl }: PickSlabProps) {
 
   const isMutating = addReactionMutation.isPending || removeReactionMutation.isPending;
 
-  // Team accent colors for colorful picks (simplified - can be enhanced with user settings later)
-  const teamInfo = TeamMap[teamCode as keyof typeof TeamMap];
-  const colorfulPicks = true; // TODO: Get from user settings
-
   return (
-    <div
-      className={cn(
-        'rounded-lg relative bg-background p-[2px]',
-        colorfulPicks && 'animate-gradient'
-      )}
-      style={{
-        backgroundImage:
-          colorfulPicks && teamInfo?.accent
-            ? `conic-gradient(from 0deg at 50% 50%, 
-              ${teamInfo.accent.primary} 0deg,
-              ${teamInfo.accent.secondary} 180deg,
-              ${teamInfo.accent.primary} 360deg)`
-            : undefined,
-      }}
-    >
-      <div
-        className="rounded-lg bg-background/90 flex gap-2 p-2 w-full"
-        style={{
-          backgroundImage:
-            colorfulPicks && teamInfo?.accent
-              ? `linear-gradient(135deg, ${teamInfo.accent.primary}10, ${teamInfo.accent.secondary}10)`
-              : undefined,
-        }}
-      >
-        <div className="flex flex-col justify-between">
-          <Link href={`/profile/${user.username}`}>
-            <UserAvatar
-              className="w-10 h-10"
-              avatarUrl={user.avatar_url}
-              username={user.username}
-            />
+    <article className="flex gap-3 px-4 py-3 border-b border-border hover:bg-accent/30 transition-colors">
+      <div className="shrink-0">
+        <Link href={`/profile/${user.username}`}>
+          <UserAvatar
+            className="w-10 h-10"
+            avatarUrl={user.avatar_url}
+            username={user.username}
+          />
+        </Link>
+      </div>
+      <div className="grow min-w-0 flex flex-col gap-1">
+        <div className="flex items-center gap-2 flex-wrap">
+          <Link
+            href={`/profile/${user.username}`}
+            className="text-sm font-semibold hover:underline"
+          >
+            @{user.username}
           </Link>
-          <span className="text-xs text-muted-foreground flex items-center gap-1 tabular-nums">
+          <span className="text-xs text-muted-foreground tabular-nums">
             {createdAt}
           </span>
         </div>
-        <div className="grow flex flex-col">
-          <div className="flex items-center gap-2 justify-between">
-            <span className="text-sm opacity-50">@{user.username}</span>
-            <div className="flex items-center rounded-lg bg-secondary text-secondary-foreground">
-              <Logo tricode={teamCode} className="w-6 h-6" />
-              <span className="py-1 pr-2 text-xs text-nowrap">{teamName}</span>
-            </div>
-          </div>
 
-          <div className="flex">
-            <div className="grow text-md break-words">
-              <p>{pick.comment}</p>
-              {matchupUrl && (
-                <Link
-                  href={matchupUrl}
-                  className="text-xs text-primary hover:underline pt-2 inline-flex items-end gap-1"
-                >
-                  View matchup <ExternalLinkIcon className="w-4 h-4" />
-                </Link>
-              )}
-            </div>
-            <div className="pt-2">
-              <Button
-                className="min-h-12"
-                variant="ghost"
-                onClick={handleLike}
-                disabled={isLoading || isMutating}
+        {pick.comment && (
+          <p className="text-sm leading-relaxed break-words">{pick.comment}</p>
+        )}
+
+        <div className="flex items-center justify-between mt-1">
+          <div className="flex items-center gap-3">
+            {matchupUrl && (
+              <Link
+                href={matchupUrl}
+                className="text-xs text-primary hover:underline inline-flex items-center gap-1"
               >
-                <div className="flex flex-col items-center gap-2">
-                  <FlameIcon
-                    className={cn(
-                      'h-4 w-4',
-                      reactionData?.isLiked && 'text-destructive fill-destructive'
-                    )}
-                  />
-                  <span className="tabular-nums">
-                    {reactionData?.totalItems || 0}
-                  </span>
-                </div>
-              </Button>
-            </div>
+                View matchup <ExternalLinkIcon className="w-3 h-3" />
+              </Link>
+            )}
+            <Link
+              href={matchupUrl || '#'}
+              className="flex items-center rounded-full bg-secondary/80 text-secondary-foreground hover:bg-secondary transition-colors"
+            >
+              <Logo tricode={teamCode} className="w-5 h-5" />
+              <span className="py-0.5 pr-2 text-xs text-nowrap">{teamName}</span>
+            </Link>
           </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="gap-1.5 text-muted-foreground hover:text-destructive"
+            onClick={handleLike}
+            disabled={isLoading || isMutating}
+          >
+            <FlameIcon
+              className={cn(
+                'h-4 w-4 transition-transform hover:scale-110',
+                reactionData?.isLiked &&
+                  'text-destructive fill-destructive scale-110'
+              )}
+            />
+            <span className="text-xs tabular-nums">
+              {reactionData?.totalItems || 0}
+            </span>
+          </Button>
         </div>
       </div>
-    </div>
+    </article>
   );
 }
-

--- a/next-app/components/navigation/bottom-nav.tsx
+++ b/next-app/components/navigation/bottom-nav.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Home, User, Trophy, LogIn } from 'lucide-react';
+import { Home, User, Trophy, LogIn, CalendarDays } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface NavItem {
@@ -21,6 +21,7 @@ export function BottomNav({ isAuthenticated }: BottomNavProps) {
 
   const navItems: NavItem[] = [
     { href: '/home', label: 'Home', icon: Home, id: 'home' },
+    { href: '/games', label: 'Games', icon: CalendarDays, id: 'games' },
     ...(isAuthenticated
       ? [
           {
@@ -46,6 +47,7 @@ export function BottomNav({ isAuthenticated }: BottomNavProps) {
             pathname === item.href ||
             (item.href === '/leaderboard' &&
               pathname.startsWith('/leaderboard')) ||
+            (item.href === '/games' && pathname === '/games') ||
             (item.href === '/login' && pathname === '/login');
           return (
             <Link

--- a/next-app/components/navigation/top-nav.tsx
+++ b/next-app/components/navigation/top-nav.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Home, User, LogIn, LogOut, Trophy } from 'lucide-react';
+import { Home, User, LogIn, LogOut, Trophy, CalendarDays } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { cn } from '@/lib/utils';
@@ -43,6 +43,16 @@ export function TopNav({ isAuthenticated, username }: TopNavProps) {
             >
               <Home className="h-4 w-4" />
               <span>Home</span>
+            </Link>
+            <Link
+              href="/games"
+              className={cn(
+                'flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-all hover:bg-accent hover:text-accent-foreground',
+                pathname === '/games' ? 'bg-accent text-accent-foreground' : 'text-muted-foreground'
+              )}
+            >
+              <CalendarDays className="h-4 w-4" />
+              <span>Games</span>
             </Link>
             <Link
               href="/leaderboard"

--- a/next-app/components/ui/pick-skeleton.tsx
+++ b/next-app/components/ui/pick-skeleton.tsx
@@ -1,0 +1,27 @@
+export function PickSlabSkeleton() {
+  return (
+    <div className="flex gap-3 px-4 py-3 animate-pulse">
+      <div className="shrink-0">
+        <div className="w-10 h-10 rounded-full bg-muted" />
+      </div>
+      <div className="grow min-w-0 flex flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <div className="w-20 h-4 bg-muted rounded" />
+          <div className="w-8 h-3 bg-muted rounded" />
+        </div>
+        <div className="w-full h-4 bg-muted rounded" />
+        <div className="w-3/4 h-4 bg-muted rounded" />
+        <div className="flex items-center justify-between mt-1">
+          <div className="flex items-center gap-3">
+            <div className="w-20 h-3 bg-muted rounded" />
+            <div className="flex items-center rounded-full bg-muted/50 h-5 gap-1">
+              <div className="w-5 h-5 rounded-full bg-muted" />
+              <div className="w-10 h-4 rounded-r-full" />
+            </div>
+          </div>
+          <div className="w-10 h-6 bg-muted rounded" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/next-app/components/weekly/latest-picks-view.tsx
+++ b/next-app/components/weekly/latest-picks-view.tsx
@@ -1,12 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef, useCallback } from 'react';
-import {
-  Carousel,
-  CarouselContent,
-  CarouselItem,
-} from '@/components/ui/carousel';
-import { PickSlabSkeleton } from '@/components/ui/pick-slab-skeleton';
+import { PickSlabSkeleton } from '@/components/ui/pick-skeleton';
 import type { PickType } from '@/lib/definitions';
 import { TeamMap } from '@/lib/team-map';
 import { Logo } from '@/components/nba/logo';
@@ -17,7 +11,6 @@ import { useAddReaction, useRemoveReaction } from '@/lib/mutations';
 import { DateTime } from 'luxon';
 import Link from 'next/link';
 import { ExternalLinkIcon, FlameIcon } from 'lucide-react';
-import type { CarouselApi } from '@/components/ui/carousel';
 import { cn } from '@/lib/utils';
 
 interface UserProfile {
@@ -28,21 +21,15 @@ interface UserProfile {
 
 export function LatestPicksViewSkeleton() {
   return (
-    <div className="w-full max-w-2xl mx-auto">
-      <Carousel className="w-full">
-        <CarouselContent>
-          {[1, 2, 3].map((index) => (
-            <CarouselItem key={index} className="md:basis-full">
-              <PickSlabSkeleton />
-            </CarouselItem>
-          ))}
-        </CarouselContent>
-      </Carousel>
+    <div className="w-full mx-auto space-y-3">
+      {[1, 2, 3, 4, 5].map((index) => (
+        <PickSlabSkeleton key={index} />
+      ))}
     </div>
   );
 }
 
-function PickSlab({
+function FeedPickCard({
   pick,
   user,
   matchupUrl,
@@ -87,8 +74,8 @@ function PickSlab({
     addReactionMutation.isPending || removeReactionMutation.isPending;
 
   return (
-    <div className="border border-border rounded-lg p-2 flex gap-2">
-      <div className="flex flex-col justify-between">
+    <article className="flex gap-3 px-4 py-3 border-b border-border hover:bg-accent/30 transition-colors">
+      <div className="shrink-0">
         <Link href={`/profile/${user.username}`}>
           <UserAvatar
             className="w-10 h-10"
@@ -96,55 +83,63 @@ function PickSlab({
             username={user.username}
           />
         </Link>
-        <span className="text-xs text-muted-foreground flex items-center gap-1 tabular-nums">
-          {createdAt}
-        </span>
       </div>
-      <div className="grow flex flex-col">
-        <div className="flex items-center gap-2 justify-between">
-          <span className="text-sm opacity-50">@{user.username}</span>
-          <div className="flex items-center rounded-lg bg-secondary text-secondary-foreground">
-            <Logo tricode={teamCode} className="w-6 h-6" />
-            <span className="py-1 pr-2 text-xs text-nowrap">{teamName}</span>
-          </div>
+      <div className="grow min-w-0 flex flex-col gap-1">
+        <div className="flex items-center gap-2 flex-wrap">
+          <Link
+            href={`/profile/${user.username}`}
+            className="text-sm font-semibold hover:underline"
+          >
+            @{user.username}
+          </Link>
+          <span className="text-xs text-muted-foreground tabular-nums">
+            {createdAt}
+          </span>
         </div>
 
-        <div className="flex">
-          <div className="grow text-md break-words">
-            <p>{pick.comment}</p>
+        {pick.comment && (
+          <p className="text-sm leading-relaxed break-words">{pick.comment}</p>
+        )}
+
+        <div className="flex items-center justify-between mt-1">
+          <div className="flex items-center gap-3">
             {matchupUrl && (
               <Link
                 href={matchupUrl}
-                className="text-xs text-primary hover:underline pt-2 inline-flex items-end gap-1"
+                className="text-xs text-primary hover:underline inline-flex items-center gap-1"
               >
-                View matchup <ExternalLinkIcon className="w-4 h-4" />
+                View matchup <ExternalLinkIcon className="w-3 h-3" />
               </Link>
             )}
-          </div>
-          <div className="pt-2">
-            <Button
-              className="min-h-12"
-              variant="ghost"
-              onClick={handleLike}
-              disabled={isLoading || isMutating}
+            <Link
+              href={matchupUrl || '#'}
+              className="flex items-center rounded-full bg-secondary/80 text-secondary-foreground hover:bg-secondary transition-colors"
             >
-              <div className="flex flex-col items-center gap-2">
-                <FlameIcon
-                  className={cn(
-                    'h-4 w-4',
-                    reactionData?.isLiked &&
-                      'text-destructive fill-destructive'
-                  )}
-                />
-                <span className="tabular-nums">
-                  {reactionData?.totalItems || 0}
-                </span>
-              </div>
-            </Button>
+              <Logo tricode={teamCode} className="w-5 h-5" />
+              <span className="py-0.5 pr-2 text-xs text-nowrap">{teamName}</span>
+            </Link>
           </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="gap-1.5 text-muted-foreground hover:text-destructive"
+            onClick={handleLike}
+            disabled={isLoading || isMutating}
+          >
+            <FlameIcon
+              className={cn(
+                'h-4 w-4 transition-transform hover:scale-110',
+                reactionData?.isLiked &&
+                  'text-destructive fill-destructive scale-110'
+              )}
+            />
+            <span className="text-xs tabular-nums">
+              {reactionData?.totalItems || 0}
+            </span>
+          </Button>
         </div>
       </div>
-    </div>
+    </article>
   );
 }
 
@@ -157,99 +152,44 @@ export function LatestPicksView({
   users: UserProfile[];
   isLoading?: boolean;
 }) {
-  const [api, setApi] = useState<CarouselApi | null>(null);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const [autoScrollEnabled, setAutoScrollEnabled] = useState(true);
-  const isAutoScrollingRef = useRef(false);
-
-  const scrollNext = useCallback(() => {
-    if (api) {
-      isAutoScrollingRef.current = true;
-      api.scrollNext();
-      setTimeout(() => {
-        isAutoScrollingRef.current = false;
-      }, 100);
-    }
-  }, [api]);
-
-  const stopAutoScroll = useCallback(() => {
-    setAutoScrollEnabled(false);
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
-    }
-  }, []);
-
-  const handleManualNavigation = useCallback(() => {
-    if (!isAutoScrollingRef.current) {
-      stopAutoScroll();
-    }
-  }, [stopAutoScroll]);
-
-  useEffect(() => {
-    if (picks.length > 1 && api && autoScrollEnabled) {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-      }
-      intervalRef.current = setInterval(scrollNext, 5000);
-      return () => {
-        if (intervalRef.current) {
-          clearInterval(intervalRef.current);
-        }
-      };
-    }
-  }, [api, picks.length, scrollNext, autoScrollEnabled]);
-
-  useEffect(() => {
-    if (!api) return;
-    api.on('select', handleManualNavigation);
-    return () => {
-      api.off('select', handleManualNavigation);
-    };
-  }, [api, handleManualNavigation]);
-
   if (isLoading) {
     return <LatestPicksViewSkeleton />;
   }
 
+  if (picks.length === 0) {
+    return (
+      <div className="text-center py-16 text-muted-foreground">
+        <p className="text-lg font-medium">No picks yet</p>
+        <p className="text-sm mt-1">Check back later for picks from the community</p>
+      </div>
+    );
+  }
+
   return (
-    <div className="w-full max-w-2xl mx-auto">
-      {picks.length === 0 ? (
-        <div className="text-center py-8 text-muted-foreground">
-          No picks available
-        </div>
-      ) : (
-        <Carousel
-          setApi={setApi}
-          className="w-full"
-          opts={{
-            align: 'start',
-            loop: true,
-          }}
+    <div className="w-full mx-auto divide-y divide-border">
+      {picks.map((pick, index) => (
+        <div
+          key={pick.id}
+          className="animate-in fade-in slide-in-from-bottom-2 duration-300"
+          style={{ animationDelay: `${Math.min(index, 5) * 75}ms`, animationFillMode: 'both' }}
         >
-          <CarouselContent>
-            {picks.map((pick) => (
-              <CarouselItem key={pick.id} className="md:basis-full">
-                <PickSlab
-                  pick={pick}
-                  user={
-                    users.find((u) => u.id === pick.user) || {
-                      id: pick.user,
-                      username: 'unknown',
-                      avatar_url: null,
-                    }
-                  }
-                  matchupUrl={
-                    pick.expand?.matchup?.code
-                      ? `/matchup/${pick.expand.matchup.code}`
-                      : undefined
-                  }
-                />
-              </CarouselItem>
-            ))}
-          </CarouselContent>
-        </Carousel>
-      )}
+          <FeedPickCard
+            pick={pick}
+            user={
+              users.find((u) => u.id === pick.user) || {
+                id: pick.user,
+                username: 'unknown',
+                avatar_url: null,
+              }
+            }
+            matchupUrl={
+              pick.expand?.matchup?.code
+                ? `/matchup/${pick.expand.matchup.code}`
+                : undefined
+            }
+          />
+        </div>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **Homepage now shows picks in a vertical scrollable feed** (Twitter-style) instead of an auto-scrolling carousel. Each pick card naturally expands to fit its comment length, eliminating weird gaps in layout.
- **Games/Matchups moved to `/games`** — the previous homepage content (GamesView with date picker) now lives at its own route.
- **Navigation updated** — new "Games" nav item added to both top nav and bottom nav with CalendarDays icon.

## Changes

| File | Change |
|------|--------|
| `components/weekly/latest-picks-view.tsx` | Removed carousel, rendered as vertical list with staggered fade-in animation |
| `components/matchup/pick-slab.tsx` | Clean Twitter-inspired card: avatar left, content right, team badge as clickable pill, flame reactions |
| `app/home/page.tsx` | Now only shows picks feed (limit increased to 20) |
| `app/games/page.tsx` | **New** — games/matchups moved here with date picker |
| `components/navigation/bottom-nav.tsx` | Added Games nav item |
| `components/navigation/top-nav.tsx` | Added Games nav item |
| `components/ui/pick-skeleton.tsx` | **New** — skeleton matching feed card layout |

## Design

Twitter-inspired feed with:
- Avatar + username row linking to profile
- Team badge as clickable pill linking to matchup
- Flame reaction button with hover scale effect
- Staggered fade-in on load
- Border-bottom dividers between picks

## Checks
- ✅ Lint passes (no new issues)
- ✅ Build succeeds
- ✅ All 130 tests pass